### PR TITLE
Add protocol as a required field

### DIFF
--- a/deploy/crds/v1/nifi.orange.com_nificlusters_crd.yaml
+++ b/deploy/crds/v1/nifi.orange.com_nificlusters_crd.yaml
@@ -593,6 +593,7 @@ spec:
                             type: string
                         required:
                         - containerPort
+                        - protocol
                         type: object
                       type: array
                       x-kubernetes-list-map-keys:


### PR DESCRIPTION
Protocol is required in x-kubernetes-list-map-keys and as such must be added to the list of required fields

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #33
| License         | Apache 2.0


### What's in this PR?
The addition of a required field to the nifiClusters Custom Resource Definition.

### Why?
The resource won;t be accepted by Kubernetes due to implicit OpenAPI rules.
```
The CustomResourceDefinition "nificlusters.nifi.orange.com" is invalid: spec.validation.openAPIV3Schema.properties[spec].properties[initContainers].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property
```
### Additional context
When trying to deploy the operator, I came across an error when loading the nifi.orange.com_nificlusters_crd.yam into the cluster.
My cluster is an Openshift 4.5 (Kubernetes 1.18)


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [ ] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [ ] Append changelog with changes
