### PR TITLE
Replace hardcoded FSGroup (1000) with property

### DIFF
--- a/api/v1alpha1/nificluster_types.go
+++ b/api/v1alpha1/nificluster_types.go
@@ -190,6 +190,9 @@ type NodeConfig struct {
 	//RunAsUser define the id of the user to run in the Nifi image
 	// +kubebuilder:validation:Minimum=1
 	RunAsUser *int64 `json:"runAsUser,omitempty"`
+	//FSGroup define the id of the group for each volumes in Nifi image
+	// +kubebuilder:validation:Minimum=1
+	FSGroup *int64 `json:"FSGroup,omitempty"`
 	// Set this to true if the instance is a node in a cluster.
 	// https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#basic-cluster-setup
 	IsNode *bool `json:"isNode,omitempty"`
@@ -541,6 +544,16 @@ func (nConfig *NodeConfig) GetRunAsUser() *int64 {
 	}
 
 	return func(i int64) *int64 { return &i }(defaultUserID)
+}
+
+//
+func (nConfig *NodeConfig) GetFSGroup() *int64 {
+	var defaultGroupID int64 = 1000
+	if nConfig.FSGroup != nil {
+		return nConfig.FSGroup
+	}
+
+	return func(i int64) *int64 { return &i }(defaultGroupID)
 }
 
 //

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -976,6 +976,11 @@ func (in *NodeConfig) DeepCopyInto(out *NodeConfig) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.FSGroup != nil {
+		in, out := &in.FSGroup, &out.FSGroup
+		*out = new(int64)
+		**out = **in
+	}
 	if in.IsNode != nil {
 		in, out := &in.IsNode, &out.IsNode
 		*out = new(bool)

--- a/config/crd/bases/nifi.orange.com_nificlusters.yaml
+++ b/config/crd/bases/nifi.orange.com_nificlusters.yaml
@@ -1415,6 +1415,12 @@ spec:
                 additionalProperties:
                   description: NodeConfig defines the node configuration
                   properties:
+                    FSGroup:
+                      description: FSGroup define the id of the group for each volumes
+                        in Nifi image
+                      format: int64
+                      minimum: 1
+                      type: integer
                     image:
                       description: ' Docker image used by the operator to create the
                         node associated  https://hub.docker.com/r/apache/nifi/'
@@ -1917,6 +1923,12 @@ spec:
                     nodeConfig:
                       description: node configuration
                       properties:
+                        FSGroup:
+                          description: FSGroup define the id of the group for each
+                            volumes in Nifi image
+                          format: int64
+                          minimum: 1
+                          type: integer
                         image:
                           description: ' Docker image used by the operator to create
                             the node associated  https://hub.docker.com/r/apache/nifi/'

--- a/pkg/resources/nifi/pod.go
+++ b/pkg/resources/nifi/pod.go
@@ -126,7 +126,7 @@ func (r *Reconciler) pod(id int32, nodeConfig *v1alpha1.NodeConfig, pvcs []corev
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsUser:    nodeConfig.GetRunAsUser(),
 				RunAsNonRoot: func(b bool) *bool { return &b }(true),
-				FSGroup:      func(i int64) *int64 { return &i }(1000),
+				FSGroup:      nodeConfig.GetFSGroup(),
 			},
 			InitContainers: append(initContainers, []corev1.Container{
 				{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0

### What's in this PR?
Replace hardcoded FSGroup (1000) with property.
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

### Why?
It useful then run NiFi cluster on secured cluster, e.g. on Openshift without ability to create SCC.
You must define `runAsUser: 1000780000` and `FSGroup: 1000780000` to run nifi containers under `default` openshift service account.
Hardcoded `FSGroup: 1000` force us to create SCC to run NiFi containers. 
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] add FSGroup param to docs