### PR TITLE
[Fix/Operator] Manage several NiFiClusters with the same managed user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed Bugs
 
 - [PR #62](https://github.com/Orange-OpenSource/nifikop/pull/62) - **[Operator/NifiCluster]** Fix DNS names for services in all-node mode.
+- [PR #64](https://github.com/Orange-OpenSource/nifikop/pull/64) - **[Operator/NifiCluster]** Manage several NiFiClusters with the same managed user.
 
 ## v0.4.3
 

--- a/pkg/resources/nifi/nifi.go
+++ b/pkg/resources/nifi/nifi.go
@@ -649,7 +649,7 @@ func (r *Reconciler) reconcileNifiUsersAndGroups(log logr.Logger) error {
 	for _, managedUser := range managedUsers {
 		users = append(users, &v1alpha1.NifiUser{
 			ObjectMeta: templates.ObjectMeta(
-				managedUser.Name,
+				fmt.Sprintf("%s.%s",r.NifiCluster.Name, managedUser.Name),
 				pkicommon.LabelsForNifiPKI(r.NifiCluster.Name), r.NifiCluster,
 			),
 			Spec: v1alpha1.NifiUserSpec{
@@ -682,7 +682,7 @@ func (r *Reconciler) reconcileNifiUsersAndGroups(log logr.Logger) error {
 		// Managed admins
 		{
 			ObjectMeta: templates.ObjectMeta(
-				"managed-admins",
+				fmt.Sprintf("%s.managed-admins", r.NifiCluster.Name),
 				pkicommon.LabelsForNifiPKI(r.NifiCluster.Name), r.NifiCluster,
 			),
 			Spec: v1alpha1.NifiUserGroupSpec{
@@ -735,7 +735,7 @@ func (r *Reconciler) reconcileNifiUsersAndGroups(log logr.Logger) error {
 		// Managed Readers
 		{
 			ObjectMeta: templates.ObjectMeta(
-				"managed-readers",
+				fmt.Sprintf("%s.managed-readers", r.NifiCluster.Name),
 				pkicommon.LabelsForNifiPKI(r.NifiCluster.Name), r.NifiCluster,
 			),
 			Spec: v1alpha1.NifiUserGroupSpec{
@@ -768,7 +768,7 @@ func (r *Reconciler) reconcileNifiUsersAndGroups(log logr.Logger) error {
 		// Managed Nodes
 		{
 			ObjectMeta: templates.ObjectMeta(
-				"managed-nodes",
+				fmt.Sprintf("%s.managed-nodes", r.NifiCluster.Name),
 				pkicommon.LabelsForNifiPKI(r.NifiCluster.Name), r.NifiCluster,
 			),
 			Spec: v1alpha1.NifiUserGroupSpec{

--- a/pkg/resources/nifi/nifi.go
+++ b/pkg/resources/nifi/nifi.go
@@ -665,12 +665,12 @@ func (r *Reconciler) reconcileNifiUsersAndGroups(log logr.Logger) error {
 
 	var managedAdminUserRef []v1alpha1.UserReference
 	for _, user := range r.NifiCluster.Spec.ManagedAdminUsers {
-		managedAdminUserRef = append(managedAdminUserRef, v1alpha1.UserReference{Name: user.Name})
+		managedAdminUserRef = append(managedAdminUserRef, v1alpha1.UserReference{Name: fmt.Sprintf("%s.%s",r.NifiCluster.Name, user.Name)})
 	}
 
 	var managedReaderUserRef []v1alpha1.UserReference
 	for _, user := range r.NifiCluster.Spec.ManagedReaderUsers {
-		managedReaderUserRef = append(managedReaderUserRef, v1alpha1.UserReference{Name: user.Name})
+		managedReaderUserRef = append(managedReaderUserRef, v1alpha1.UserReference{Name: fmt.Sprintf("%s.%s",r.NifiCluster.Name, user.Name)})
 	}
 
 	var managedNodeUserRef []v1alpha1.UserReference


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #63 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

It adds the cluster name in NiFiUser and NiFiUserGroup resources managed by the operator.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

It allows to have many NiFiCluster in the same namespace defining the same users and groups

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes