### PR TITLE
adjustable retention and loglevel in logback.xml

### DIFF
--- a/api/v1alpha1/nificluster_types.go
+++ b/api/v1alpha1/nificluster_types.go
@@ -86,6 +86,8 @@ type NifiClusterSpec struct {
 	SidecarConfigs []corev1.Container `json:"sidecarConfigs,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=containers"`
 	// ExternalService specifies settings required to access nifi externally
 	ExternalServices []ExternalServiceConfig `json:"externalServices,omitempty"`
+
+	Logback Logback `json:"logback,omitempty"`
 }
 
 // DisruptionBudget defines the configuration for PodDisruptionBudget
@@ -440,6 +442,54 @@ type ManagedUser struct {
 	// name field is use to name the NifiUser resource, if not identity is provided it will be used to name
 	// the user on NiFi cluster side.
 	Name string `json:"name"`
+}
+
+type Logback struct {
+	MaxHistory  MaxHistory  `json:"maxHistory,omitempty"`
+	MaxFileSize MaxFileSize `json:"maxFileSize,omitempty"`
+	LogLevel    LogLevel    `json:"logLevel,omitempty"`
+}
+
+type MaxHistory struct {
+	AppFile       int `json:"appFile,omitempty"`
+	UserFile      int `json:"userFile,omitempty"`
+	BootstrapFile int `json:"bootstrapFile,omitempty"`
+}
+
+type MaxFileSize struct {
+	AppFile string `json:"appFile,omitempty"`
+}
+
+type LogLevel struct {
+	Nifi                                           string `json:"nifi,omitempty"`
+	NifiProcessors                                 string `json:"nifiProcessors,omitempty"`
+	NifiProcessorsStandardLogAttribute             string `json:"nifiProcessorsStandardLogAttribute,omitempty"`
+	NifiProcessorsStandardLogMessage               string `json:"nifiProcessorsStandardLogMessage,omitempty"`
+	NifiControllerRepositoryStandardProcessSession string `json:"nifiControllerRepositoryStandardProcessSession,omitempty"`
+	ZookeeperClientCnxn                            string `json:"zookeeperClientCnxn,omitempty"`
+	ZookeeperServerNIOServerCnxn                   string `json:"zookeeperServerNIOServerCnxn,omitempty"`
+	ZookeeperServerNIOServerCnxnFactory            string `json:"zookeeperServerNIOServerCnxnFactory,omitempty"`
+	ZookeeperServerQuorum                          string `json:"zookeeperServerQuorum,omitempty"`
+	ZookeeperZooKeeper                             string `json:"zookeeperZooKeeper,omitempty"`
+	ZookeeperServerPrepRequestProcessor            string `json:"zookeeperServerPrepRequestProcessor,omitempty"`
+	CalciteRuntimeCalciteException                 string `json:"calciteRuntimeCalciteException,omitempty"`
+	CuratorFrameworkRecipesLeaderLeaderSelector    string `json:"curatorFrameworkRecipesLeaderLeaderSelector,omitempty"`
+	CuratorConnectionState                         string `json:"curatorConnectionState,omitempty"`
+	NifiCluster                                    string `json:"nifiCluster,omitempty"`
+	NifiServerJettyServer                          string `json:"nifiServerJettyServer,omitempty"`
+	Jetty                                          string `json:"jetty,omitempty"`
+	Springframework                                string `json:"springframework,omitempty"`
+	JerseyInternalErrors                           string `json:"jerseyInternalErrors,omitempty"`
+	NifiWebSecurity                                string `json:"nifiWebSecurity,omitempty"`
+	NifiWebApiConfig                               string `json:"nifiWebApiConfig,omitempty"`
+	NifiAuthorization                              string `json:"nifiAuthorization,omitempty"`
+	NifiClusterAuthorization                       string `json:"nifiClusterAuthorization,omitempty"`
+	NifiWebFilterRequestLogger                     string `json:"nifiWebFilterRequestLogger,omitempty"`
+	NifiBootstrap                                  string `json:"nifiBootstrap,omitempty"`
+	NifiBootstrapCommand                           string `json:"nifiBootstrapCommand,omitempty"`
+	NifiStdOut                                     string `json:"nifiStdOut,omitempty"`
+	NifiStdErr                                     string `json:"nifiStdErr,omitempty"`
+	Root                                           string `json:"root,omitempty"`
 }
 
 func (u *ManagedUser) GetIdentity() string {

--- a/pkg/resources/nifi/configmap.go
+++ b/pkg/resources/nifi/configmap.go
@@ -281,11 +281,57 @@ func (r *Reconciler) getLoginIdentityProvidersConfigString(nConfig *v1alpha1.Nod
 //
 func (r *Reconciler) getLogbackConfigString(nConfig *v1alpha1.NodeConfig, id int32, log logr.Logger) string {
 
+	crIntOrDefault := func(crValue, defaultValue int) int {
+		if crValue != 0 {
+			return crValue
+		}
+		return defaultValue
+	}
+	crStringOrDefault := func(crValue, defaultValue string) string {
+		if crValue != "" {
+			return crValue
+		}
+		return defaultValue
+	}
+
 	var out bytes.Buffer
 	t := template.Must(template.New("nConfig-config").Parse(config.LogbackTemplate))
 	if err := t.Execute(&out, map[string]interface{}{
-		"NifiCluster": r.NifiCluster,
-		"Id":          id,
+		"NifiCluster":             r.NifiCluster,
+		"Id":                      id,
+		"MaxHistoryAppFile":       crIntOrDefault(r.NifiCluster.Spec.Logback.MaxHistory.AppFile, 30),
+		"MaxHistoryUserFile":      crIntOrDefault(r.NifiCluster.Spec.Logback.MaxHistory.UserFile, 30),
+		"MaxHistoryBootstrapFile": crIntOrDefault(r.NifiCluster.Spec.Logback.MaxHistory.BootstrapFile, 5),
+		"MaxFileSizeAppFile":      crStringOrDefault(r.NifiCluster.Spec.Logback.MaxFileSize.AppFile, "100MB"),
+		"LogLevelNifi":            crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.Nifi, "INFO"),
+		"LogLevelNifiProcessors":  crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.NifiProcessors, "WARN"),
+		"LogLevelNifiProcessorsStandardLogAttribute":             crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.NifiProcessorsStandardLogAttribute, "INFO"),
+		"LogLevelNifiProcessorsStandardLogMessage":               crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.NifiProcessorsStandardLogMessage, "INFO"),
+		"LogLevelNifiControllerRepositoryStandardProcessSession": crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.NifiControllerRepositoryStandardProcessSession, "WARN"),
+		"LogLevelZookeeperClientCnxn":                            crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.ZookeeperClientCnxn, "ERROR"),
+		"LogLevelZookeeperServerNIOServerCnxn":                   crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.ZookeeperServerNIOServerCnxn, "ERROR"),
+		"LogLevelZookeeperServerNIOServerCnxnFactory":            crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.ZookeeperServerNIOServerCnxnFactory, "ERROR"),
+		"LogLevelZookeeperServerQuorum":                          crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.ZookeeperServerQuorum, "ERROR"),
+		"LogLevelZookeeperZooKeeper":                             crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.ZookeeperZooKeeper, "ERROR"),
+		"LogLevelZookeeperServerPrepRequestProcessor":            crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.ZookeeperServerPrepRequestProcessor, "ERROR"),
+		"LogLevelCalciteRuntimeCalciteException":                 crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.CalciteRuntimeCalciteException, "OFF"),
+		"LogLevelCuratorFrameworkRecipesLeaderLeaderSelector":    crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.CuratorFrameworkRecipesLeaderLeaderSelector, "OFF"),
+		"LogLevelCuratorConnectionState":                         crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.CuratorConnectionState, "OFF"),
+		"LogLevelNifiCluster":                                    crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.NifiCluster, "DEBUG"),
+		"LogLevelNifiServerJettyServer":                          crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.NifiServerJettyServer, "INFO"),
+		"LogLevelJetty":                                          crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.Jetty, "INFO"),
+		"LogLevelSpringframework":                                crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.Springframework, "ERROR"),
+		"LogLevelJerseyInternalErrors":                           crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.JerseyInternalErrors, "ERROR"),
+		"LogLevelNifiWebSecurity":                                crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.NifiWebSecurity, "INFO"),
+		"LogLevelNifiWebApiConfig":                               crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.NifiWebApiConfig, "INFO"),
+		"LogLevelNifiAuthorization":                              crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.NifiAuthorization, "INFO"),
+		"LogLevelNifiClusterAuthorization":                       crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.NifiClusterAuthorization, "INFO"),
+		"LogLevelNifiWebFilterRequestLogger":                     crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.NifiWebFilterRequestLogger, "INFO"),
+		"LogLevelNifiBootstrap":                                  crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.NifiBootstrap, "INFO"),
+		"LogLevelNifiBootstrapCommand":                           crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.NifiBootstrapCommand, "INFO"),
+		"LogLevelNifiStdOut":                                     crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.NifiStdOut, "INFO"),
+		"LogLevelNifiStdErr":                                     crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.NifiStdErr, "ERROR"),
+		"LogLevelRoot":                                           crStringOrDefault(r.NifiCluster.Spec.Logback.LogLevel.Root, "INFO"),
 	}); err != nil {
 		log.Error(err, "error occurred during parsing the config template")
 	}

--- a/pkg/resources/templates/config/logback.xml.go
+++ b/pkg/resources/templates/config/logback.xml.go
@@ -44,9 +44,9 @@ var LogbackTemplate = `<?xml version="1.0" encoding="UTF-8"?>
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
             <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-app_%d{yyyy-MM-dd_HH}.%i.log</fileNamePattern>
-            <maxFileSize>100MB</maxFileSize>
+            <maxFileSize>{{.MaxFileSizeAppFile}}</maxFileSize>
             <!-- keep 30 log files worth of history -->
-            <maxHistory>30</maxHistory>
+            <maxHistory>{{.MaxHistoryAppFile}}</maxHistory>
         </rollingPolicy>
         <immediateFlush>true</immediateFlush>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
@@ -65,7 +65,7 @@ var LogbackTemplate = `<?xml version="1.0" encoding="UTF-8"?>
             -->
             <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-user_%d.log</fileNamePattern>
             <!-- keep 30 log files worth of history -->
-            <maxHistory>30</maxHistory>
+            <maxHistory>{{.MaxHistoryUserFile}}</maxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>%date %level [%thread] %logger{40} %msg%n</pattern>
@@ -83,7 +83,7 @@ var LogbackTemplate = `<?xml version="1.0" encoding="UTF-8"?>
             -->
             <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-bootstrap_%d.log</fileNamePattern>
             <!-- keep 5 log files worth of history -->
-            <maxHistory>5</maxHistory>
+            <maxHistory>{{.MaxHistoryBootstrapFile}}</maxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>%date %level [%thread] %logger{40} %msg%n</pattern>
@@ -98,58 +98,58 @@ var LogbackTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     
     <!-- valid logging levels: TRACE, DEBUG, INFO, WARN, ERROR -->
     
-    <logger name="org.apache.nifi" level="INFO"/>
-    <logger name="org.apache.nifi.processors" level="WARN"/>
-    <logger name="org.apache.nifi.processors.standard.LogAttribute" level="INFO"/>
-    <logger name="org.apache.nifi.processors.standard.LogMessage" level="INFO"/>
-    <logger name="org.apache.nifi.controller.repository.StandardProcessSession" level="WARN" />
+    <logger name="org.apache.nifi" level="{{.LogLevelNifi}}"/>
+    <logger name="org.apache.nifi.processors" level="{{.LogLevelNifiProcessors}}"/>
+    <logger name="org.apache.nifi.processors.standard.LogAttribute" level="{{.LogLevelNifiProcessorsStandardLogAttribute}}"/>
+    <logger name="org.apache.nifi.processors.standard.LogMessage" level="{{.LogLevelNifiProcessorsStandardLogMessage}}"/>
+    <logger name="org.apache.nifi.controller.repository.StandardProcessSession" level="{{.LogLevelNifiControllerRepositoryStandardProcessSession}}" />
     
     
-    <logger name="org.apache.zookeeper.ClientCnxn" level="ERROR" />
-    <logger name="org.apache.zookeeper.server.NIOServerCnxn" level="ERROR" />
-    <logger name="org.apache.zookeeper.server.NIOServerCnxnFactory" level="ERROR" />
-    <logger name="org.apache.zookeeper.server.quorum" level="ERROR" />
-    <logger name="org.apache.zookeeper.ZooKeeper" level="ERROR" />
-    <logger name="org.apache.zookeeper.server.PrepRequestProcessor" level="ERROR" />
+    <logger name="org.apache.zookeeper.ClientCnxn" level="{{.LogLevelZookeeperClientCnxn}}" />
+    <logger name="org.apache.zookeeper.server.NIOServerCnxn" level="{{.LogLevelZookeeperServerNIOServerCnxn}}" />
+    <logger name="org.apache.zookeeper.server.NIOServerCnxnFactory" level="{{.LogLevelZookeeperServerNIOServerCnxnFactory}}" />
+    <logger name="org.apache.zookeeper.server.quorum" level="{{.LogLevelZookeeperServerQuorum}}" />
+    <logger name="org.apache.zookeeper.ZooKeeper" level="{{.LogLevelZookeeperZooKeeper}}" />
+    <logger name="org.apache.zookeeper.server.PrepRequestProcessor" level="{{.LogLevelZookeeperServerPrepRequestProcessor}}" />
 
-    <logger name="org.apache.calcite.runtime.CalciteException" level="OFF" />
+    <logger name="org.apache.calcite.runtime.CalciteException" level="{{.LogLevelCalciteRuntimeCalciteException}}" />
 
-    <logger name="org.apache.curator.framework.recipes.leader.LeaderSelector" level="OFF" />
-    <logger name="org.apache.curator.ConnectionState" level="OFF" />
+    <logger name="org.apache.curator.framework.recipes.leader.LeaderSelector" level="{{.LogLevelCuratorFrameworkRecipesLeaderLeaderSelector}}" />
+    <logger name="org.apache.curator.ConnectionState" level="{{.LogLevelCuratorConnectionState}}" />
     
     <!-- Logger for managing logging statements for nifi clusters. -->
-    <logger name="org.apache.nifi.cluster" level="DEBUG"/>
+    <logger name="org.apache.nifi.cluster" level="{{.LogLevelNifiCluster}}"/>
 
     <!-- Logger for logging HTTP requests received by the web server. -->
-    <logger name="org.apache.nifi.server.JettyServer" level="INFO"/>
+    <logger name="org.apache.nifi.server.JettyServer" level="{{.LogLevelNifiServerJettyServer}}"/>
 
     <!-- Logger for managing logging statements for jetty -->
-    <logger name="org.eclipse.jetty" level="INFO"/>
+    <logger name="org.eclipse.jetty" level="{{.LogLevelJetty}}"/>
 
     <!-- Suppress non-error messages due to excessive logging by class or library -->
-    <logger name="org.springframework" level="ERROR"/>
+    <logger name="org.springframework" level="{{.LogLevelSpringframework}}"/>
     
     <!-- Suppress non-error messages due to known warning about redundant path annotation (NIFI-574) -->
-    <logger name="org.glassfish.jersey.internal.Errors" level="ERROR"/>
+    <logger name="org.glassfish.jersey.internal.Errors" level="{{.LogLevelJerseyInternalErrors}}"/>
 
     <!--
         Logger for capturing user events. We do not want to propagate these
         log events to the root logger. These messages are only sent to the
         user-log appender.
     -->
-    <logger name="org.apache.nifi.web.security" level="INFO" additivity="false">
+    <logger name="org.apache.nifi.web.security" level="{{.LogLevelNifiWebSecurity}}" additivity="false">
         <appender-ref ref="USER_FILE"/>
     </logger>
-    <logger name="org.apache.nifi.web.api.config" level="INFO" additivity="false">
+    <logger name="org.apache.nifi.web.api.config" level="{{.LogLevelNifiWebApiConfig}}" additivity="false">
         <appender-ref ref="USER_FILE"/>
     </logger>
-    <logger name="org.apache.nifi.authorization" level="INFO" additivity="false">
+    <logger name="org.apache.nifi.authorization" level="{{.LogLevelNifiAuthorization}}" additivity="false">
         <appender-ref ref="USER_FILE"/>
     </logger>
-    <logger name="org.apache.nifi.cluster.authorization" level="INFO" additivity="false">
+    <logger name="org.apache.nifi.cluster.authorization" level="{{.LogLevelNifiClusterAuthorization}}" additivity="false">
         <appender-ref ref="USER_FILE"/>
     </logger>
-    <logger name="org.apache.nifi.web.filter.RequestLogger" level="INFO" additivity="false">
+    <logger name="org.apache.nifi.web.filter.RequestLogger" level="{{.LogLevelNifiWebFilterRequestLogger}}" additivity="false">
         <appender-ref ref="USER_FILE"/>
     </logger>
 
@@ -157,26 +157,26 @@ var LogbackTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <!--
         Logger for capturing Bootstrap logs and NiFi's standard error and standard out. 
     -->
-    <logger name="org.apache.nifi.bootstrap" level="INFO" additivity="false">
+    <logger name="org.apache.nifi.bootstrap" level="{{.LogLevelNifiBootstrap}}" additivity="false">
         <appender-ref ref="BOOTSTRAP_FILE" />
     </logger>
-    <logger name="org.apache.nifi.bootstrap.Command" level="INFO" additivity="false">
+    <logger name="org.apache.nifi.bootstrap.Command" level="{{.LogLevelNifiBootstrapCommand}}" additivity="false">
         <appender-ref ref="CONSOLE" />
         <appender-ref ref="BOOTSTRAP_FILE" />
     </logger>
 
     <!-- Everything written to NiFi's Standard Out will be logged with the logger org.apache.nifi.StdOut at INFO level -->
-    <logger name="org.apache.nifi.StdOut" level="INFO" additivity="false">
+    <logger name="org.apache.nifi.StdOut" level="{{.LogLevelNifiStdOut}}" additivity="false">
         <appender-ref ref="BOOTSTRAP_FILE" />
     </logger>
     
     <!-- Everything written to NiFi's Standard Error will be logged with the logger org.apache.nifi.StdErr at ERROR level -->
-    <logger name="org.apache.nifi.StdErr" level="ERROR" additivity="false">
+    <logger name="org.apache.nifi.StdErr" level="{{.LogLevelNifiStdErr}}" additivity="false">
         <appender-ref ref="BOOTSTRAP_FILE" />
     </logger>
 
 
-    <root level="INFO">
+    <root level="{{.LogLevelRoot}}">
         <appender-ref ref="APP_FILE"/>
     </root>
     


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no?
| New feature?    | yes
| API breaks?     | no
| Deprications?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Possibility to change retention and loglevel in logback.xaml via CR.


### Why?
Retention time of logfiles and loglevels are currently hardcoded in https://github.com/Orange-OpenSource/nifikop/blob/master/pkg/resources/templates/config/logback.xml.go


### Additional context
In case of no additional values in CR: default values are used. CR is also not extended (keeps it clean).
Usage to overwrite defaults via CR:
```
apiVersion: nifi.orange.com/v1alpha1
kind: NifiCluster
spec:
  logback:
    maxHistory:
      appFile: 30
      userFile: 30
      bootstrapFile: 5
    maxFileSize: 
      appFile: "100MB"
    logLevel:
      nifi: "INFO"
      nifiProcessors: "WARN"
      nifiProcessorsStandardLogAttribute: "INFO"
      nifiProcessorsStandardLogMessage: "INFO"
      nifiControllerRepositoryStandardProcessSession: "WARN"
      zookeeperClientCnxn: "ERROR"
      zookeeperServerNIOServerCnxn: "ERROR"
      zookeeperServerNIOServerCnxnFactory: "ERROR"
      zookeeperServerQuorum: "ERROR"
      zookeeperZooKeeper: "ERROR"
      zookeeperServerPrepRequestProcessor: "ERROR"
      calciteRuntimeCalciteException: "OFF"
      curatorFrameworkRecipesLeaderLeaderSelector: "OFF"
      curatorConnectionState: "OFF"
      nifiCluster: "DEBUG"
      nifiServerJettyServer: "INFO"
      jetty: "INFO"
      springframework: "ERROR"
      jerseyInternalErrors: "ERROR"
      nifiWebSecurity: "INFO"
      nifiWebApiConfig": "INFO"
      nifiAuthorization: "INFO"
      nifiClusterAuthorization: "INFO"
      nifiWebFilterRequestLogger: "INFO"
      nifiBootstrap: "INFO"
      nifiBootstrapCommand: "INFO"
      nifiStdOut: "INFO"
      nifiStdErr: "ERROR"
      root: "INFO"
```
Specify only configs that should be other than default.

### Checklist

- [x] Implementation tested
- [ ] Comments as documentation added
- [ ] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [ ] Append changelog with changes

### To Do
- [ ] Do you think it's an appropriate solution?

Basically we would prefer something like:
```
apiVersion: nifi.orange.com/v1alpha1
kind: NifiCluster
spec:
  logconfigoverride:
    configMap: logback
    namespace: default
```
but the logback.xml is already in a confimap that contains multiple config files (fully managed by the operator).