### PR TITLE
[Fix/Operator] Enable empty value for parameter context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed Bugs
 
+- [PR #82](https://github.com/Orange-OpenSource/nifikop/pull/82) - **[Operator/NifiParameterContext]** Enable empty value
+
 ## v0.5.2
 
 ### Fixed Bugs

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.15
 require (
 	emperror.dev/errors v0.4.2
 	github.com/antihax/optional v1.0.0
+	github.com/erdrix/nigoapi v0.0.0-20210301104455-ab202e217b78
 	github.com/banzaicloud/k8s-objectmatcher v1.4.1
-	github.com/erdrix/nigoapi v0.0.0-20200824133217-ce90b74151a2
 	github.com/go-logr/logr v0.3.0
 	github.com/imdario/mergo v0.3.10
 	github.com/jarcoal/httpmock v1.0.6
@@ -26,3 +26,4 @@ require (
 )
 
 //replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM
+// 	github.com/erdrix/nigoapi v0.0.0-20200824133217-ce90b74151a2

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erdrix/nigoapi v0.0.0-20200824133217-ce90b74151a2 h1:WJ1tS9+ENB2z+sVgpt2pAOZbLIFxFLFzK87RL0uvx00=
 github.com/erdrix/nigoapi v0.0.0-20200824133217-ce90b74151a2/go.mod h1:owY+8fs8YXnST3ENM+ulVllYjTbzGaqKA+Y7HHJ0lZA=
+github.com/erdrix/nigoapi v0.0.0-20210301104455-ab202e217b78 h1:X63Z+rOVlAXl+GGCSN24yZDjEMRTtcDADzXSCLCJq/8=
+github.com/erdrix/nigoapi v0.0.0-20210301104455-ab202e217b78/go.mod h1:owY+8fs8YXnST3ENM+ulVllYjTbzGaqKA+Y7HHJ0lZA=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=

--- a/pkg/clientwrappers/parametercontext/parametercontext.go
+++ b/pkg/clientwrappers/parametercontext/parametercontext.go
@@ -155,7 +155,7 @@ func parameterContextIsSync(
 			if expected.Parameter.Name == param.Parameter.Name {
 				notFound = false
 
-				if (!param.Parameter.Sensitive && expected.Parameter.Value != param.Parameter.Value) ||
+				if (!param.Parameter.Sensitive && *expected.Parameter.Value != *param.Parameter.Value) ||
 					expected.Parameter.Description != param.Parameter.Description {
 
 					return false
@@ -202,7 +202,7 @@ func updateRequestPrepare(
 			if expected.Parameter.Name == param.Parameter.Name {
 				notFound = false
 
-				if (!param.Parameter.Sensitive && expected.Parameter.Value != param.Parameter.Value) ||
+				if (!param.Parameter.Sensitive && *expected.Parameter.Value != *param.Parameter.Value) ||
 					expected.Parameter.Description != param.Parameter.Description {
 					notFound = false
 					parameters = append(parameters, expected)
@@ -247,24 +247,26 @@ func updateParameterContextEntity(parameterContext *v1alpha1.NifiParameterContex
 
 	for _, secret := range parameterSecrets {
 		for k, v := range secret.Data {
+			value := string(v)
 			parameters = append(parameters, nigoapi.ParameterEntity{
 				Parameter: &nigoapi.ParameterDto{
 					Name:        k,
 					Description: "",
 					Sensitive:   true,
-					Value:       string(v),
+					Value:       &value,
 				},
 			})
 		}
 	}
 
 	for _, parameter := range parameterContext.Spec.Parameters {
+		value := parameter.Value
 		parameters = append(parameters, nigoapi.ParameterEntity{
 			Parameter: &nigoapi.ParameterDto{
 				Name:        parameter.Name,
 				Description: parameter.Description,
 				Sensitive:   false,
-				Value:       parameter.Value,
+				Value:       &value,
 			},
 		})
 	}

--- a/pkg/nificlient/parametercontext_test.go
+++ b/pkg/nificlient/parametercontext_test.go
@@ -261,7 +261,7 @@ func map2Parameters(params map[string]string, sensitive bool) []nigoapi.Paramete
 				Name:        k,
 				Description: "",
 				Sensitive:   sensitive,
-				Value:       v,
+				Value:       &v,
 			},
 		})
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #79 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

It contains a fix that allow to manage empty value for parameter context correctly. 

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Now an empty value is set as an empty string in NiFi instead of not set.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes