### PR TITLE
[Feature/Operator] Add events and improve HTTP calls error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Added
 
+- [PR #86](https://github.com/Orange-OpenSource/nifikop/pull/86) - **[Operator/Debugging]** Add events and improve HTTP calls error message
+
+
 ### Changed
 
 - [PR #85](https://github.com/Orange-OpenSource/nifikop/pull/85) - **[Operator/Dependencies]** Upgrade cert-manager & operator sdk dependencies

--- a/controllers/nificluster_controller.go
+++ b/controllers/nificluster_controller.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"time"
 
@@ -50,6 +51,7 @@ type NifiClusterReconciler struct {
 	Log          logr.Logger
 	Scheme       *runtime.Scheme
 	Namespaces   []string
+	Recorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/nificlustertask_controller.go
+++ b/controllers/nificlustertask_controller.go
@@ -26,6 +26,7 @@ import (
 	nifiutil "github.com/Orange-OpenSource/nifikop/pkg/util/nifi"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/tools/record"
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -45,6 +46,7 @@ type NifiClusterTaskReconciler struct {
 	client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/controllers/nifiregistryclient_controller.go
+++ b/controllers/nifiregistryclient_controller.go
@@ -18,10 +18,13 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"github.com/Orange-OpenSource/nifikop/pkg/clientwrappers/registryclient"
 	"github.com/Orange-OpenSource/nifikop/pkg/k8sutil"
 	"github.com/Orange-OpenSource/nifikop/pkg/util"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"time"
@@ -41,6 +44,7 @@ type NifiRegistryClientReconciler struct {
 	client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=nifi.orange.com,resources=nifiregistryclients,verbs=get;list;watch;create;update;patch;delete
@@ -85,6 +89,9 @@ func (r *NifiRegistryClientReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return Reconciled()
 		}
 
+		r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceClusterError",
+			fmt.Sprintf("Failed to lookup reference cluster : %s in %s",
+				instance.Spec.ClusterRef.Name, clusterNamespace ))
 		// the cluster does not exist - should have been caught pre-flight
 		return RequeueWithError(r.Log, "failed to lookup referenced cluster", err)
 	}
@@ -94,6 +101,9 @@ func (r *NifiRegistryClientReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return r.checkFinalizers(ctx, r.Log, instance, cluster)
 	}
 
+	r.Recorder.Event(instance, corev1.EventTypeNormal, "Reconciling",
+		fmt.Sprintf("Reconciling registry client %s", instance.Name ))
+
 	// Check if the NiFi registry client already exist
 	exist, err := registryclient.ExistRegistryClient(r.Client, instance, cluster)
 	if err != nil {
@@ -102,6 +112,8 @@ func (r *NifiRegistryClientReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	if !exist {
 		// Create NiFi registry client
+		r.Recorder.Event(instance, corev1.EventTypeNormal, "Creating",
+			fmt.Sprintf("Creating registry client %s", instance.Name ))
 		status, err := registryclient.CreateRegistryClient(r.Client, instance, cluster)
 		if err != nil {
 			return RequeueWithError(r.Log, "failure creating registry client", err)
@@ -111,11 +123,18 @@ func (r *NifiRegistryClientReconciler) Reconcile(ctx context.Context, req ctrl.R
 		if err := r.Client.Status().Update(ctx, instance); err != nil {
 			return RequeueWithError(r.Log, "failed to update NifiRegistryClient status", err)
 		}
+
+		r.Recorder.Event(instance, corev1.EventTypeNormal, "Created",
+			fmt.Sprintf("Created registry client %s", instance.Name ))
 	}
 
 	// Sync RegistryClient resource with NiFi side component
+	r.Recorder.Event(instance, corev1.EventTypeNormal, "Synchronizing",
+		fmt.Sprintf("Synchronizing registry client %s", instance.Name ))
 	status, err := registryclient.SyncRegistryClient(r.Client, instance, cluster)
 	if err != nil {
+		r.Recorder.Event(instance, corev1.EventTypeNormal, "SynchronizingFailed",
+			fmt.Sprintf("Synchronizing registry client %s failed", instance.Name ))
 		return RequeueWithError(r.Log, "failed to sync NifiRegistryClient", err)
 	}
 
@@ -124,6 +143,8 @@ func (r *NifiRegistryClientReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return RequeueWithError(r.Log, "failed to update NifiRegistryClient status", err)
 	}
 
+	r.Recorder.Event(instance, corev1.EventTypeNormal, "Synchronized",
+		fmt.Sprintf("Synchronized registry client %s", instance.Name ))
 	// Ensure NifiCluster label
 	if instance, err = r.ensureClusterLabel(ctx, cluster, instance); err != nil {
 		return RequeueWithError(r.Log, "failed to ensure NifiCluster label on registry client", err)
@@ -139,6 +160,9 @@ func (r *NifiRegistryClientReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if instance, err = r.updateAndFetchLatest(ctx, instance); err != nil {
 		return RequeueWithError(r.Log, "failed to update NifiRegistryClient", err)
 	}
+
+	r.Recorder.Event(instance, corev1.EventTypeNormal, "Reconciled",
+		fmt.Sprintf("Reconciling registry client %s", instance.Name ))
 
 	r.Log.Info("Ensured Registry Client")
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,8 @@ require (
 	emperror.dev/errors v0.4.2
 	github.com/antihax/optional v1.0.0
 	github.com/banzaicloud/k8s-objectmatcher v1.4.1
-	github.com/erdrix/nigoapi v0.0.0-20210301104455-ab202e217b78
+	github.com/erdrix/nigoapi v0.0.0-20210322100900-9bf87aec43d9
+	//	github.com/erdrix/nigoapi v0.0.0-20210301104455-ab202e217b78
 	github.com/go-logr/logr v0.3.0
 	github.com/imdario/mergo v0.3.10
 	github.com/jarcoal/httpmock v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,10 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/erdrix/nigoapi v0.0.0-20210301104455-ab202e217b78 h1:X63Z+rOVlAXl+GGCSN24yZDjEMRTtcDADzXSCLCJq/8=
-github.com/erdrix/nigoapi v0.0.0-20210301104455-ab202e217b78/go.mod h1:owY+8fs8YXnST3ENM+ulVllYjTbzGaqKA+Y7HHJ0lZA=
+github.com/erdrix/nigoapi v0.0.0-20210322095543-c804ede67990 h1:SWQx+KhQXXW5p9S1V4s5No0Bdmo+Lpc0Xo2FIwHNxNQ=
+github.com/erdrix/nigoapi v0.0.0-20210322095543-c804ede67990/go.mod h1:owY+8fs8YXnST3ENM+ulVllYjTbzGaqKA+Y7HHJ0lZA=
+github.com/erdrix/nigoapi v0.0.0-20210322100900-9bf87aec43d9 h1:yqGp8oivds/3m/9BT93zhEN+WvWSMJS5AClOoeVeeAs=
+github.com/erdrix/nigoapi v0.0.0-20210322100900-9bf87aec43d9/go.mod h1:owY+8fs8YXnST3ENM+ulVllYjTbzGaqKA+Y7HHJ0lZA=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=

--- a/main.go
+++ b/main.go
@@ -127,6 +127,7 @@ func main() {
 		Log:          ctrl.Log.WithName("controllers").WithName("NifiCluster"),
 		Scheme:       mgr.GetScheme(),
 		Namespaces:   namespaceList,
+		Recorder: mgr.GetEventRecorderFor("nifi-cluster"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NifiCluster")
 		os.Exit(1)
@@ -136,6 +137,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("NifiClusterTask"),
 		Scheme: mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("nifi-cluster-task"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NifiClusterTask")
 		os.Exit(1)
@@ -145,6 +147,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("NifiUser"),
 		Scheme: mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("nifi-user"),
 	}).SetupWithManager(mgr, certManagerEnabled); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NifiUser")
 		os.Exit(1)
@@ -154,6 +157,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("NifiUserGroup"),
 		Scheme: mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("nifi-user-group"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NifiUserGroup")
 		os.Exit(1)
@@ -163,6 +167,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("NifiDataflow"),
 		Scheme: mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("nifi-dataflow"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NifiDataflow")
 		os.Exit(1)
@@ -172,6 +177,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("NifiParameterContext"),
 		Scheme: mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("nifi-parameter-context"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NifiParameterContext")
 		os.Exit(1)
@@ -181,6 +187,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("NifiRegistryClient"),
 		Scheme: mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("nifi-registry-client"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NifiRegistryClient")
 		os.Exit(1)

--- a/pkg/nificlient/common.go
+++ b/pkg/nificlient/common.go
@@ -28,14 +28,14 @@ var ErrNifiClusterNodeNotFound = errors.New("The target node id doesn't exist in
 
 var ErrNoNodeClientsAvailable = errors.New("Cannot create a node client to perform actions")
 
-func errorGetOperation(rsp *http.Response, err error) error {
+func errorGetOperation(rsp *http.Response, body *string, err error) error {
 	if rsp != nil && rsp.StatusCode == 404 {
 		log.Info("404 response from nifi node: " + rsp.Status)
 		return ErrNifiClusterReturned404
 	}
 
 	if rsp != nil && rsp.StatusCode != 200 {
-		log.Error(errors.New("Non 200 response from nifi node: "+rsp.Status), "Error during talking to nifi node")
+		log.Error(errors.New("Non 200 response from nifi node: "+rsp.Status), *body)
 		return ErrNifiClusterNotReturned200
 	}
 
@@ -46,9 +46,9 @@ func errorGetOperation(rsp *http.Response, err error) error {
 	return nil
 }
 
-func errorCreateOperation(rsp *http.Response, err error) error {
+func errorCreateOperation(rsp *http.Response, body *string, err error) error {
 	if rsp != nil && rsp.StatusCode != 201 {
-		log.Error(errors.New("Non 201 response from nifi node: "+rsp.Status), "Error during talking to nifi node")
+		log.Error(errors.New("Non 201 response from nifi node: "+rsp.Status), *body)
 		return ErrNifiClusterNotReturned201
 	}
 
@@ -60,9 +60,9 @@ func errorCreateOperation(rsp *http.Response, err error) error {
 	return nil
 }
 
-func errorUpdateOperation(rsp *http.Response, err error) error {
+func errorUpdateOperation(rsp *http.Response, body *string, err error) error {
 	if rsp != nil && rsp.StatusCode != 200 && rsp.StatusCode != 202 {
-		log.Error(errors.New("Non 200 response from nifi node: "+rsp.Status), "Error during talking to nifi node")
+		log.Error(errors.New("Non 200 response from nifi node: "+rsp.Status), *body)
 		return ErrNifiClusterNotReturned200
 	}
 
@@ -74,14 +74,14 @@ func errorUpdateOperation(rsp *http.Response, err error) error {
 	return nil
 }
 
-func errorDeleteOperation(rsp *http.Response, err error) error {
+func errorDeleteOperation(rsp *http.Response, body *string, err error) error {
 	if rsp != nil && rsp.StatusCode == 404 {
-		log.Error(errors.New("404 response from nifi node: "+rsp.Status), "No registry client to remove found")
+		log.Error(errors.New("404 response from nifi node: "+rsp.Status), *body)
 		return nil
 	}
 
 	if rsp != nil && rsp.StatusCode != 200 {
-		log.Error(errors.New("Non 200 response from nifi node: "+rsp.Status), "Error during talking to nifi node")
+		log.Error(errors.New("Non 200 response from nifi node: "+rsp.Status), *body)
 		return ErrNifiClusterNotReturned200
 	}
 

--- a/pkg/nificlient/flow.go
+++ b/pkg/nificlient/flow.go
@@ -14,8 +14,8 @@ func (n *nifiClient) GetFlow(id string) (*nigoapi.ProcessGroupFlowEntity, error)
 	}
 
 	// Request on Nifi Rest API to get the process group flow informations
-	flowPGEntity, rsp, err := client.FlowApi.GetFlow(nil, id)
-	if err := errorGetOperation(rsp, err); err != nil {
+	flowPGEntity, rsp, body, err := client.FlowApi.GetFlow(nil, id)
+	if err := errorGetOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -31,13 +31,13 @@ func (n *nifiClient) GetFlowControllerServices(id string) (*nigoapi.ControllerSe
 	}
 
 	// Request on Nifi Rest API to get the process group flow's controller services informations
-	csEntity, rsp, err := client.FlowApi.GetControllerServicesFromGroup(nil, id,
+	csEntity, rsp, body, err := client.FlowApi.GetControllerServicesFromGroup(nil, id,
 		&nigoapi.FlowApiGetControllerServicesFromGroupOpts{
 			IncludeAncestorGroups:   optional.NewBool(false),
 			IncludeDescendantGroups: optional.NewBool(true),
 		})
 
-	if err := errorGetOperation(rsp, err); err != nil {
+	if err := errorGetOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -54,8 +54,8 @@ func (n *nifiClient) UpdateFlowControllerServices(entity nigoapi.ActivateControl
 	}
 
 	// Request on Nifi Rest API to enable or disable the controller services
-	csEntity, rsp, err := client.FlowApi.ActivateControllerServices(nil, entity.Id, entity)
-	if err := errorUpdateOperation(rsp, err); err != nil {
+	csEntity, rsp, body, err := client.FlowApi.ActivateControllerServices(nil, entity.Id, entity)
+	if err := errorUpdateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -72,8 +72,8 @@ func (n *nifiClient) UpdateFlowProcessGroup(entity nigoapi.ScheduleComponentsEnt
 	}
 
 	// Request on Nifi Rest API to enable or disable the controller services
-	csEntity, rsp, err := client.FlowApi.ScheduleComponents(nil, entity.Id, entity)
-	if err := errorUpdateOperation(rsp, err); err != nil {
+	csEntity, rsp, body, err := client.FlowApi.ScheduleComponents(nil, entity.Id, entity)
+	if err := errorUpdateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nificlient/flowfiles.go
+++ b/pkg/nificlient/flowfiles.go
@@ -13,8 +13,8 @@ func (n *nifiClient) GetDropRequest(connectionId, id string) (*nigoapi.DropReque
 	}
 
 	// Request on Nifi Rest API to get the drop request information
-	dropRequest, rsp, err := client.FlowfileQueuesApi.GetDropRequest(nil, connectionId, id)
-	if err := errorGetOperation(rsp, err); err != nil {
+	dropRequest, rsp, body, err := client.FlowfileQueuesApi.GetDropRequest(nil, connectionId, id)
+	if err := errorGetOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -30,8 +30,8 @@ func (n *nifiClient) CreateDropRequest(connectionId string) (*nigoapi.DropReques
 	}
 
 	// Request on Nifi Rest API to create the drop Request
-	entity, rsp, err := client.FlowfileQueuesApi.CreateDropRequest(nil, connectionId)
-	if err := errorCreateOperation(rsp, err); err != nil {
+	entity, rsp, body, err := client.FlowfileQueuesApi.CreateDropRequest(nil, connectionId)
+	if err := errorCreateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nificlient/inputport.go
+++ b/pkg/nificlient/inputport.go
@@ -11,8 +11,8 @@ func (n *nifiClient) UpdateInputPortRunStatus(id string, entity nigoapi.PortRunS
 	}
 
 	// Request on Nifi Rest API to update the input port run status
-	processor, rsp, err := client.InputPortsApi.UpdateRunStatus(nil, id, entity)
-	if err := errorUpdateOperation(rsp, err); err != nil {
+	processor, rsp, body, err := client.InputPortsApi.UpdateRunStatus(nil, id, entity)
+	if err := errorUpdateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nificlient/parametercontext.go
+++ b/pkg/nificlient/parametercontext.go
@@ -30,8 +30,8 @@ func (n *nifiClient) GetParameterContext(id string) (*nigoapi.ParameterContextEn
 	}
 
 	// Request on Nifi Rest API to get the parameter context informations
-	pcEntity, rsp, err := client.ParameterContextsApi.GetParameterContext(nil, id)
-	if err := errorGetOperation(rsp, err); err != nil {
+	pcEntity, rsp, body, err := client.ParameterContextsApi.GetParameterContext(nil, id)
+	if err := errorGetOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -47,8 +47,8 @@ func (n *nifiClient) CreateParameterContext(entity nigoapi.ParameterContextEntit
 	}
 
 	// Request on Nifi Rest API to create the parameter context
-	pcEntity, rsp, err := client.ParameterContextsApi.CreateParameterContext(nil, entity)
-	if err := errorCreateOperation(rsp, err); err != nil {
+	pcEntity, rsp, body, err := client.ParameterContextsApi.CreateParameterContext(nil, entity)
+	if err := errorCreateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -64,12 +64,12 @@ func (n *nifiClient) RemoveParameterContext(entity nigoapi.ParameterContextEntit
 	}
 
 	// Request on Nifi Rest API to remove the parameter context
-	_, rsp, err := client.ParameterContextsApi.DeleteParameterContext(nil, entity.Id,
+	_, rsp, body, err := client.ParameterContextsApi.DeleteParameterContext(nil, entity.Id,
 		&nigoapi.ParameterContextsApiDeleteParameterContextOpts{
 			Version: optional.NewString(strconv.FormatInt(*entity.Revision.Version, 10)),
 		})
 
-	return errorDeleteOperation(rsp, err)
+	return errorDeleteOperation(rsp, body, err)
 }
 
 func (n *nifiClient) CreateParameterContextUpdateRequest(contextId string, entity nigoapi.ParameterContextEntity) (*nigoapi.ParameterContextUpdateRequestEntity, error) {
@@ -81,8 +81,8 @@ func (n *nifiClient) CreateParameterContextUpdateRequest(contextId string, entit
 	}
 
 	// Request on Nifi Rest API to create the parameter context update request
-	request, rsp, err := client.ParameterContextsApi.SubmitParameterContextUpdate(nil, contextId, entity)
-	if err := errorUpdateOperation(rsp, err); err != nil {
+	request, rsp, body, err := client.ParameterContextsApi.SubmitParameterContextUpdate(nil, contextId, entity)
+	if err := errorUpdateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -98,8 +98,8 @@ func (n *nifiClient) GetParameterContextUpdateRequest(contextId, id string) (*ni
 	}
 
 	// Request on Nifi Rest API to get the parameter context update request information
-	request, rsp, err := client.ParameterContextsApi.GetParameterContextUpdate(nil, contextId, id)
-	if err := errorGetOperation(rsp, err); err != nil {
+	request, rsp, body, err := client.ParameterContextsApi.GetParameterContextUpdate(nil, contextId, id)
+	if err := errorGetOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nificlient/policies.go
+++ b/pkg/nificlient/policies.go
@@ -39,9 +39,9 @@ func (n *nifiClient) GetAccessPolicy(action, resource string) (*nigoapi.AccessPo
 		break
 	}
 
-	accessPolicyEntity, rsp, err := client.PoliciesApi.GetAccessPolicyForResource(nil, action, resource)
+	accessPolicyEntity, rsp, body, err := client.PoliciesApi.GetAccessPolicyForResource(nil, action, resource)
 
-	if err := errorGetOperation(rsp, err); err != nil {
+	if err := errorGetOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -57,8 +57,8 @@ func (n *nifiClient) CreateAccessPolicy(entity nigoapi.AccessPolicyEntity) (*nig
 	}
 
 	// Request on Nifi Rest API to create the access policy
-	accessPolicyEntity, rsp, err := client.PoliciesApi.CreateAccessPolicy(nil, entity)
-	if err := errorCreateOperation(rsp, err); err != nil {
+	accessPolicyEntity, rsp, body, err := client.PoliciesApi.CreateAccessPolicy(nil, entity)
+	if err := errorCreateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -74,8 +74,8 @@ func (n *nifiClient) UpdateAccessPolicy(entity nigoapi.AccessPolicyEntity) (*nig
 	}
 
 	// Request on Nifi Rest API to update the access policy
-	accessPolicyEntity, rsp, err := client.PoliciesApi.UpdateAccessPolicy(nil, entity.Id, entity)
-	if err := errorUpdateOperation(rsp, err); err != nil {
+	accessPolicyEntity, rsp, body, err := client.PoliciesApi.UpdateAccessPolicy(nil, entity.Id, entity)
+	if err := errorUpdateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -91,10 +91,10 @@ func (n *nifiClient) RemoveAccessPolicy(entity nigoapi.AccessPolicyEntity) error
 	}
 
 	// Request on Nifi Rest API to remove the registry client
-	_, rsp, err := client.PoliciesApi.RemoveAccessPolicy(nil, entity.Id,
+	_, rsp, body, err := client.PoliciesApi.RemoveAccessPolicy(nil, entity.Id,
 		&nigoapi.PoliciesApiRemoveAccessPolicyOpts{
 			Version: optional.NewString(strconv.FormatInt(*entity.Revision.Version, 10)),
 		})
 
-	return errorDeleteOperation(rsp, err)
+	return errorDeleteOperation(rsp, body, err)
 }

--- a/pkg/nificlient/processgroup.go
+++ b/pkg/nificlient/processgroup.go
@@ -16,8 +16,8 @@ func (n *nifiClient) GetProcessGroup(id string) (*nigoapi.ProcessGroupEntity, er
 	}
 
 	// Request on Nifi Rest API to get the process group informations
-	pGEntity, rsp, err := client.ProcessGroupsApi.GetProcessGroup(nil, id)
-	if err := errorGetOperation(rsp, err); err != nil {
+	pGEntity, rsp, body, err := client.ProcessGroupsApi.GetProcessGroup(nil, id)
+	if err := errorGetOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -35,8 +35,8 @@ func (n *nifiClient) CreateProcessGroup(
 	}
 
 	// Request on Nifi Rest API to create the versioned process group
-	pgEntity, rsp, err := client.ProcessGroupsApi.CreateProcessGroup(nil, pgParentId, entity)
-	if err := errorCreateOperation(rsp, err); err != nil {
+	pgEntity, rsp, body, err := client.ProcessGroupsApi.CreateProcessGroup(nil, pgParentId, entity)
+	if err := errorCreateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -52,8 +52,8 @@ func (n *nifiClient) UpdateProcessGroup(entity nigoapi.ProcessGroupEntity) (*nig
 	}
 
 	// Request on Nifi Rest API to update the versioned process group
-	pgEntity, rsp, err := client.ProcessGroupsApi.UpdateProcessGroup(nil, entity.Id, entity)
-	if err := errorUpdateOperation(rsp, err); err != nil {
+	pgEntity, rsp, body, err := client.ProcessGroupsApi.UpdateProcessGroup(nil, entity.Id, entity)
+	if err := errorUpdateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -69,12 +69,12 @@ func (n *nifiClient) RemoveProcessGroup(entity nigoapi.ProcessGroupEntity) error
 	}
 
 	// Request on Nifi Rest API to remove the versioned process group
-	_, rsp, err := client.ProcessGroupsApi.RemoveProcessGroup(
+	_, rsp, body, err := client.ProcessGroupsApi.RemoveProcessGroup(
 		nil,
 		entity.Id,
 		&nigoapi.ProcessGroupsApiRemoveProcessGroupOpts{
 			Version: optional.NewString(strconv.FormatInt(*entity.Revision.Version, 10)),
 		})
 
-	return errorDeleteOperation(rsp, err)
+	return errorDeleteOperation(rsp, body, err)
 }

--- a/pkg/nificlient/processor.go
+++ b/pkg/nificlient/processor.go
@@ -14,8 +14,8 @@ func (n *nifiClient) UpdateProcessorRunStatus(
 	}
 
 	// Request on Nifi Rest API to update the processor run status
-	processor, rsp, err := client.ProcessorsApi.UpdateRunStatus(nil, id, entity)
-	if err := errorUpdateOperation(rsp, err); err != nil {
+	processor, rsp, body, err := client.ProcessorsApi.UpdateRunStatus(nil, id, entity)
+	if err := errorUpdateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nificlient/registryclient.go
+++ b/pkg/nificlient/registryclient.go
@@ -30,9 +30,9 @@ func (n *nifiClient) GetRegistryClient(id string) (*nigoapi.RegistryClientEntity
 	}
 
 	// Request on Nifi Rest API to get the registy client informations
-	regCliEntity, rsp, err := client.ControllerApi.GetRegistryClient(nil, id)
+	regCliEntity, rsp, body, err := client.ControllerApi.GetRegistryClient(nil, id)
 
-	if err := errorGetOperation(rsp, err); err != nil {
+	if err := errorGetOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -48,8 +48,8 @@ func (n *nifiClient) CreateRegistryClient(entity nigoapi.RegistryClientEntity) (
 	}
 
 	// Request on Nifi Rest API to create the registry client
-	regCliEntity, rsp, err := client.ControllerApi.CreateRegistryClient(nil, entity)
-	if err := errorCreateOperation(rsp, err); err != nil {
+	regCliEntity, rsp, body, err := client.ControllerApi.CreateRegistryClient(nil, entity)
+	if err := errorCreateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -65,8 +65,8 @@ func (n *nifiClient) UpdateRegistryClient(entity nigoapi.RegistryClientEntity) (
 	}
 
 	// Request on Nifi Rest API to update the registry client
-	regCliEntity, rsp, err := client.ControllerApi.UpdateRegistryClient(nil, entity.Id, entity)
-	if err := errorUpdateOperation(rsp, err); err != nil {
+	regCliEntity, rsp, body, err := client.ControllerApi.UpdateRegistryClient(nil, entity.Id, entity)
+	if err := errorUpdateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -82,10 +82,10 @@ func (n *nifiClient) RemoveRegistryClient(entity nigoapi.RegistryClientEntity) e
 	}
 
 	// Request on Nifi Rest API to remove the registry client
-	_, rsp, err := client.ControllerApi.DeleteRegistryClient(nil, entity.Id,
+	_, rsp, body, err := client.ControllerApi.DeleteRegistryClient(nil, entity.Id,
 		&nigoapi.ControllerApiDeleteRegistryClientOpts{
 			Version: optional.NewString(strconv.FormatInt(*entity.Revision.Version, 10)),
 		})
 
-	return errorDeleteOperation(rsp, err)
+	return errorDeleteOperation(rsp, body, err)
 }

--- a/pkg/nificlient/snippet.go
+++ b/pkg/nificlient/snippet.go
@@ -11,8 +11,8 @@ func (n *nifiClient) CreateSnippet(entity nigoapi.SnippetEntity) (*nigoapi.Snipp
 	}
 
 	// Request on Nifi Rest API to create the snippet
-	snippetEntity, rsp, err := client.SnippetsApi.CreateSnippet(nil, entity)
-	if err := errorCreateOperation(rsp, err); err != nil {
+	snippetEntity, rsp, body, err := client.SnippetsApi.CreateSnippet(nil, entity)
+	if err := errorCreateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -28,8 +28,8 @@ func (n *nifiClient) UpdateSnippet(entity nigoapi.SnippetEntity) (*nigoapi.Snipp
 	}
 
 	// Request on Nifi Rest API to update the snippet
-	snippetEntity, rsp, err := client.SnippetsApi.UpdateSnippet(nil, entity.Snippet.Id, entity)
-	if err := errorUpdateOperation(rsp, err); err != nil {
+	snippetEntity, rsp, body, err := client.SnippetsApi.UpdateSnippet(nil, entity.Snippet.Id, entity)
+	if err := errorUpdateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nificlient/system.go
+++ b/pkg/nificlient/system.go
@@ -27,8 +27,8 @@ func (n *nifiClient) DescribeCluster() (*nigoapi.ClusterEntity, error) {
 		return nil, ErrNoNodeClientsAvailable
 	}
 
-	clusterEntry, rsp, err := client.ControllerApi.GetCluster(nil)
-	if err := errorGetOperation(rsp, err); err != nil {
+	clusterEntry, rsp, body, err := client.ControllerApi.GetCluster(nil)
+	if err := errorGetOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -51,9 +51,9 @@ func (n *nifiClient) GetClusterNode(nId int32) (*nigoapi.NodeEntity, error) {
 	}
 
 	// Request on Nifi Rest API to get the node information
-	nodeEntity, rsp, err := client.ControllerApi.GetNode(nil, targetedNode.NodeId)
+	nodeEntity, rsp, body, err := client.ControllerApi.GetNode(nil, targetedNode.NodeId)
 
-	if err := errorGetOperation(rsp, err); err != nil {
+	if err := errorGetOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -97,9 +97,9 @@ func (n *nifiClient) RemoveClusterNode(nId int32) error {
 	}
 
 	// Request on Nifi Rest API to remove the node
-	_, rsp, err := client.ControllerApi.DeleteNode(nil, targetedNode.NodeId)
+	_, rsp, body, err := client.ControllerApi.DeleteNode(nil, targetedNode.NodeId)
 
-	return errorDeleteOperation(rsp, err)
+	return errorDeleteOperation(rsp, body, err)
 }
 
 func (n *nifiClient) RemoveClusterNodeFromClusterNodeId(nId string) error {
@@ -111,9 +111,9 @@ func (n *nifiClient) RemoveClusterNodeFromClusterNodeId(nId string) error {
 	}
 
 	// Request on Nifi Rest API to remove the node
-	_, rsp, err := client.ControllerApi.DeleteNode(nil, nId)
+	_, rsp, body, err := client.ControllerApi.DeleteNode(nil, nId)
 
-	return errorDeleteOperation(rsp, err)
+	return errorDeleteOperation(rsp, body, err)
 }
 
 func (n *nifiClient) setClusterNodeStatus(nId int32, status, expectedActionStatus v1alpha1.ActionStep) (*nigoapi.NodeEntity, error) {
@@ -144,8 +144,8 @@ func (n *nifiClient) setClusterNodeStatus(nId int32, status, expectedActionStatu
 	targetedNode.Status = string(status)
 
 	// Request on Nifi Rest API to update the node status
-	nodeEntity, rsp, err := client.ControllerApi.UpdateNode(nil, targetedNode.NodeId, nigoapi.NodeEntity{Node: targetedNode})
-	if err := errorUpdateOperation(rsp, err); err != nil {
+	nodeEntity, rsp, body, err := client.ControllerApi.UpdateNode(nil, targetedNode.NodeId, nigoapi.NodeEntity{Node: targetedNode})
+	if err := errorUpdateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 

--- a/pkg/nificlient/user.go
+++ b/pkg/nificlient/user.go
@@ -30,9 +30,9 @@ func (n *nifiClient) GetUsers() ([]nigoapi.UserEntity, error) {
 	}
 
 	// Request on Nifi Rest API to get the users informations
-	usersEntity, rsp, err := client.TenantsApi.GetUsers(nil)
+	usersEntity, rsp, body, err := client.TenantsApi.GetUsers(nil)
 
-	if err := errorGetOperation(rsp, err); err != nil {
+	if err := errorGetOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -48,9 +48,9 @@ func (n *nifiClient) GetUser(id string) (*nigoapi.UserEntity, error) {
 	}
 
 	// Request on Nifi Rest API to get the user informations
-	userEntity, rsp, err := client.TenantsApi.GetUser(nil, id)
+	userEntity, rsp, body, err := client.TenantsApi.GetUser(nil, id)
 
-	if err := errorGetOperation(rsp, err); err != nil {
+	if err := errorGetOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -66,8 +66,8 @@ func (n *nifiClient) CreateUser(entity nigoapi.UserEntity) (*nigoapi.UserEntity,
 	}
 
 	// Request on Nifi Rest API to create the user
-	userEntity, rsp, err := client.TenantsApi.CreateUser(nil, entity)
-	if err := errorCreateOperation(rsp, err); err != nil {
+	userEntity, rsp, body, err := client.TenantsApi.CreateUser(nil, entity)
+	if err := errorCreateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -83,8 +83,8 @@ func (n *nifiClient) UpdateUser(entity nigoapi.UserEntity) (*nigoapi.UserEntity,
 	}
 
 	// Request on Nifi Rest API to update the user
-	userEntity, rsp, err := client.TenantsApi.UpdateUser(nil, entity.Id, entity)
-	if err := errorUpdateOperation(rsp, err); err != nil {
+	userEntity, rsp, body, err := client.TenantsApi.UpdateUser(nil, entity.Id, entity)
+	if err := errorUpdateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -100,10 +100,10 @@ func (n *nifiClient) RemoveUser(entity nigoapi.UserEntity) error {
 	}
 
 	// Request on Nifi Rest API to remove the user
-	_, rsp, err := client.TenantsApi.RemoveUser(nil, entity.Id,
+	_, rsp, body, err := client.TenantsApi.RemoveUser(nil, entity.Id,
 		&nigoapi.TenantsApiRemoveUserOpts{
 			Version: optional.NewString(strconv.FormatInt(*entity.Revision.Version, 10)),
 		})
 
-	return errorDeleteOperation(rsp, err)
+	return errorDeleteOperation(rsp, body, err)
 }

--- a/pkg/nificlient/usergroup.go
+++ b/pkg/nificlient/usergroup.go
@@ -30,9 +30,9 @@ func (n *nifiClient) GetUserGroups() ([]nigoapi.UserGroupEntity, error) {
 	}
 
 	// Request on Nifi Rest API to get the user groups informations
-	userGroupsEntity, rsp, err := client.TenantsApi.GetUserGroups(nil)
+	userGroupsEntity, rsp, body, err := client.TenantsApi.GetUserGroups(nil)
 
-	if err := errorGetOperation(rsp, err); err != nil {
+	if err := errorGetOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -48,9 +48,9 @@ func (n *nifiClient) GetUserGroup(id string) (*nigoapi.UserGroupEntity, error) {
 	}
 
 	// Request on Nifi Rest API to get the user groups informations
-	userGroupEntity, rsp, err := client.TenantsApi.GetUserGroup(nil, id)
+	userGroupEntity, rsp, body, err := client.TenantsApi.GetUserGroup(nil, id)
 
-	if err := errorGetOperation(rsp, err); err != nil {
+	if err := errorGetOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -66,8 +66,8 @@ func (n *nifiClient) CreateUserGroup(entity nigoapi.UserGroupEntity) (*nigoapi.U
 	}
 
 	// Request on Nifi Rest API to create the user group
-	userGroupEntity, rsp, err := client.TenantsApi.CreateUserGroup(nil, entity)
-	if err := errorCreateOperation(rsp, err); err != nil {
+	userGroupEntity, rsp, body, err := client.TenantsApi.CreateUserGroup(nil, entity)
+	if err := errorCreateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 	return &userGroupEntity, nil
@@ -82,8 +82,8 @@ func (n *nifiClient) UpdateUserGroup(entity nigoapi.UserGroupEntity) (*nigoapi.U
 	}
 
 	// Request on Nifi Rest API to update the user group
-	userGroupEntity, rsp, err := client.TenantsApi.UpdateUserGroup(nil, entity.Id, entity)
-	if err := errorUpdateOperation(rsp, err); err != nil {
+	userGroupEntity, rsp, body, err := client.TenantsApi.UpdateUserGroup(nil, entity.Id, entity)
+	if err := errorUpdateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -99,10 +99,10 @@ func (n *nifiClient) RemoveUserGroup(entity nigoapi.UserGroupEntity) error {
 	}
 
 	// Request on Nifi Rest API to remove the user group
-	_, rsp, err := client.TenantsApi.RemoveUserGroup(nil, entity.Id,
+	_, rsp, body, err := client.TenantsApi.RemoveUserGroup(nil, entity.Id,
 		&nigoapi.TenantsApiRemoveUserGroupOpts{
 			Version: optional.NewString(strconv.FormatInt(*entity.Revision.Version, 10)),
 		})
 
-	return errorDeleteOperation(rsp, err)
+	return errorDeleteOperation(rsp, body, err)
 }

--- a/pkg/nificlient/version.go
+++ b/pkg/nificlient/version.go
@@ -11,8 +11,8 @@ func (n *nifiClient) CreateVersionUpdateRequest(pgId string, entity nigoapi.Vers
 	}
 
 	// Request on Nifi Rest API to create the version update request
-	request, rsp, err := client.VersionsApi.InitiateVersionControlUpdate(nil, pgId, entity)
-	if err := errorUpdateOperation(rsp, err); err != nil {
+	request, rsp, body, err := client.VersionsApi.InitiateVersionControlUpdate(nil, pgId, entity)
+	if err := errorUpdateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -28,8 +28,8 @@ func (n *nifiClient) GetVersionUpdateRequest(id string) (*nigoapi.VersionedFlowU
 	}
 
 	// Request on Nifi Rest API to get the update request information
-	request, rsp, err := client.VersionsApi.GetUpdateRequest(nil, id)
-	if err := errorGetOperation(rsp, err); err != nil {
+	request, rsp, body, err := client.VersionsApi.GetUpdateRequest(nil, id)
+	if err := errorGetOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -45,8 +45,8 @@ func (n *nifiClient) CreateVersionRevertRequest(pgId string, entity nigoapi.Vers
 	}
 
 	// Request on Nifi Rest API to create the version revert request
-	request, rsp, err := client.VersionsApi.InitiateRevertFlowVersion(nil, pgId, entity)
-	if err := errorUpdateOperation(rsp, err); err != nil {
+	request, rsp, body, err := client.VersionsApi.InitiateRevertFlowVersion(nil, pgId, entity)
+	if err := errorUpdateOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 
@@ -62,8 +62,8 @@ func (n *nifiClient) GetVersionRevertRequest(id string) (*nigoapi.VersionedFlowU
 	}
 
 	// Request on Nifi Rest API to get the revert request information
-	request, rsp, err := client.VersionsApi.GetRevertRequest(nil, id)
-	if err := errorGetOperation(rsp, err); err != nil {
+	request, rsp, body, err := client.VersionsApi.GetRevertRequest(nil, id)
+	if err := errorGetOperation(rsp, body, err); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | partially #74 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

It adds kubernetes events for : NifiDataflows, NifiParameterContexts, NifiRegistryClients, NifiUsers, NifiUserGroups resources and log into the operator the HTTP body response when a call to the NiFi cluster failed.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

This allows for better debugging to find out what happened to a resource, and have explicit logs about the issues.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes