### PR TITLE
[Feature/Operator] Implement the maximum number of threads for timer driven processors

### DIFF
--- a/api/v1alpha1/nificluster_types.go
+++ b/api/v1alpha1/nificluster_types.go
@@ -142,6 +142,8 @@ type Node struct {
 }
 
 type ReadOnlyConfig struct {
+	// MaximumTimerDrivenThreadCount define the maximum number of threads for timer driven processors available to the system.
+	MaximumTimerDrivenThreadCount *int32 `json:"maximumTimerDrivenThreadCount,omitempty"`
 	// NifiProperties configuration that will be applied to the node.
 	NifiProperties NifiProperties `json:"nifiProperties,omitempty"`
 	// ZookeeperProperties configuration that will be applied to the node.
@@ -521,6 +523,13 @@ func (lConfig *ListenersConfig) GetClusterDomain() string {
 	}
 
 	return lConfig.ClusterDomain
+}
+
+func (nReadOnlyConfig *ReadOnlyConfig) GetMaximumTimerDrivenThreadCount() int32 {
+	if nReadOnlyConfig.MaximumTimerDrivenThreadCount == nil {
+		return 10
+	}
+	return *nReadOnlyConfig.MaximumTimerDrivenThreadCount
 }
 
 func (nTaskSpec *NifiClusterTaskSpec) GetDurationMinutes() float64 {

--- a/config/crd/bases/nifi.orange.com_nificlusters.yaml
+++ b/config/crd/bases/nifi.orange.com_nificlusters.yaml
@@ -2583,6 +2583,12 @@ spec:
                               - name
                               type: object
                           type: object
+                        maximumTimerDrivenThreadCount:
+                          description: MaximumTimerDrivenThreadCount define the maximum
+                            number of threads for timer driven processors available
+                            to the system.
+                          format: int32
+                          type: integer
                         nifiProperties:
                           description: NifiProperties configuration that will be applied
                             to the node.
@@ -2873,6 +2879,12 @@ spec:
                         - name
                         type: object
                     type: object
+                  maximumTimerDrivenThreadCount:
+                    description: MaximumTimerDrivenThreadCount define the maximum
+                      number of threads for timer driven processors available to the
+                      system.
+                    format: int32
+                    type: integer
                   nifiProperties:
                     description: NifiProperties configuration that will be applied
                       to the node.

--- a/config/samples/nifi_v1alpha1_nificluster.yaml
+++ b/config/samples/nifi_v1alpha1_nificluster.yaml
@@ -49,6 +49,8 @@ spec:
   # readOnlyConfig specifies the read-only type Nifi config cluster wide, all theses
   # will be merged with node specified readOnly configurations, so it can be overwritten per node.
   readOnlyConfig:
+    # MaximumTimerDrivenThreadCount define the maximum number of threads for timer driven processors available to the system.
+    maximumTimerDrivenThreadCount: 30
     # Logback configuration that will be applied to the node
     logbackConfig:
       # logback.xml configuration that will replace the one produced based on template

--- a/pkg/clientwrappers/controllersettings/controllersettings.go
+++ b/pkg/clientwrappers/controllersettings/controllersettings.go
@@ -1,0 +1,54 @@
+package controllersettings
+
+import (
+	"github.com/Orange-OpenSource/nifikop/api/v1alpha1"
+	"github.com/Orange-OpenSource/nifikop/pkg/clientwrappers"
+	"github.com/Orange-OpenSource/nifikop/pkg/common"
+	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var log = ctrl.Log.WithName("controllersettings-method")
+
+func controllerConfigIsSync(cluster *v1alpha1.NifiCluster, entity *nigoapi.ControllerConfigurationEntity) bool {
+	return cluster.Spec.ReadOnlyConfig.GetMaximumTimerDrivenThreadCount() == entity.Component.MaxTimerDrivenThreadCount
+}
+
+func SyncConfiguration(client client.Client, cluster *v1alpha1.NifiCluster) error {
+
+	nClient, err := common.NewNodeConnection(log, client, cluster)
+	if err != nil {
+		return err
+	}
+
+	entity, err := nClient.GetControllerConfig()
+	if err := clientwrappers.ErrorGetOperation(log, err, "Get controller config"); err != nil {
+		return err
+	}
+
+	if !controllerConfigIsSync(cluster, entity) {
+		updateControllerConfigEntity(cluster, entity)
+		entity, err = nClient.UpdateControllerConfig(*entity)
+		if err := clientwrappers.ErrorUpdateOperation(log, err, "Update controller conif"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func updateControllerConfigEntity(cluster *v1alpha1.NifiCluster, entity *nigoapi.ControllerConfigurationEntity) {
+	if entity == nil {
+		entity = &nigoapi.ControllerConfigurationEntity{}
+	}
+
+	if entity.Component == nil {
+		entity.Revision = &nigoapi.RevisionDto{
+		}
+	}
+
+	if entity.Component == nil {
+		entity.Component = &nigoapi.ControllerConfigurationDto{}
+	}
+	entity.Component.MaxTimerDrivenThreadCount = cluster.Spec.ReadOnlyConfig.GetMaximumTimerDrivenThreadCount()
+}

--- a/pkg/nificlient/client.go
+++ b/pkg/nificlient/client.go
@@ -116,6 +116,10 @@ type NifiClient interface {
 	UpdateRunStatusReportingTask(id string, entity nigoapi.ReportingTaskRunStatusEntity) (*nigoapi.ReportingTaskEntity, error)
 	RemoveReportingTask(entity nigoapi.ReportingTaskEntity) error
 
+	// ControllerConfig func
+	GetControllerConfig() (*nigoapi.ControllerConfigurationEntity, error)
+	UpdateControllerConfig(entity nigoapi.ControllerConfigurationEntity) (*nigoapi.ControllerConfigurationEntity, error)
+
 	Build() error
 }
 

--- a/pkg/nificlient/controllerconfig.go
+++ b/pkg/nificlient/controllerconfig.go
@@ -1,0 +1,55 @@
+// Copyright 2020 Orange SA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package apis
+
+package nificlient
+
+import (
+	nigoapi "github.com/erdrix/nigoapi/pkg/nifi"
+)
+
+func (n *nifiClient) GetControllerConfig() (*nigoapi.ControllerConfigurationEntity, error) {
+	// Get nigoapi client, favoring the one associated to the coordinator node.
+	client := n.privilegeCoordinatorClient()
+	if client == nil {
+		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		return nil, ErrNoNodeClientsAvailable
+	}
+
+	// Request on Nifi Rest API to get the reporting task informations
+
+	out, rsp, body, err := client.ControllerApi.GetControllerConfig(nil)
+
+	if err := errorGetOperation(rsp, body, err); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (n *nifiClient) UpdateControllerConfig(entity nigoapi.ControllerConfigurationEntity) (*nigoapi.ControllerConfigurationEntity, error) {
+	// Get nigoapi client, favoring the one associated to the coordinator node.
+	client := n.privilegeCoordinatorClient()
+	if client == nil {
+		log.Error(ErrNoNodeClientsAvailable, "Error during creating node client")
+		return nil, ErrNoNodeClientsAvailable
+	}
+
+	// Request on Nifi Rest API to update the reporting task
+	out, rsp, body, err := client.ControllerApi.UpdateControllerConfig(nil, entity)
+	if err := errorUpdateOperation(rsp, body, err); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}

--- a/site/docs/5_references/1_nifi_cluster/2_read_only_config.md
+++ b/site/docs/5_references/1_nifi_cluster/2_read_only_config.md
@@ -8,6 +8,8 @@ ReadOnlyConfig object specifies the read-only type Nifi config cluster wide, all
 
 ```yaml
 readOnlyConfig:
+  # MaximumTimerDrivenThreadCount define the maximum number of threads for timer driven processors available to the system.
+  maximumTimerDrivenThreadCount: 30
   # Logback configuration that will be applied to the node
   logbackConfig:
     # logback.xml configuration that will replace the one produced based on template
@@ -121,6 +123,7 @@ readOnlyConfig:
 
 |Field|Type|Description|Required|Default|
 |-----|----|-----------|--------|--------|
+|maximumTimerDrivenThreadCount|int32|define the maximum number of threads for timer driven processors available to the system.|No|nil|
 |nifiProperties|[NifiProperties](#nifiproperties)|nifi.properties configuration that will be applied to the node.|No|nil|
 |zookeeperProperties|[ZookeeperProperties](#zookeeperproperties)|zookeeper.properties configuration that will be applied to the node.|No|nil|
 |bootstrapProperties|[BootstrapProperties](#bootstrapproperties)|bootstrap.conf configuration that will be applied to the node.|No|nil|


### PR DESCRIPTION
…onfiguration

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

It adds the `NifiCluster.Spec.ReadOnlyConfig.MaximumTimerDrivenThreadCount` field allowing to define the maximum number of threads for timer driven processors available to the system.
### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->



### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [ ] Append changelog with changes

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here