### PR TITLE
[Feature/Operator] Add empty_dir volume for /tmp dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - [PR #97](https://github.com/Orange-OpenSource/nifikop/pull/97) - **[Operator/NifiCluster]** Add ability to o define the maximum number of threads for timer driven processors available to the system.
+- [PR #98](https://github.com/Orange-OpenSource/nifikop/pull/98) - **[Operator/NifiCluster]**  Add empty_dir volume for `/tmp` dir.
 
 ### Changed
 

--- a/pkg/resources/nifi/nifi.go
+++ b/pkg/resources/nifi/nifi.go
@@ -51,6 +51,7 @@ const (
 	componentName = "nifi"
 
 	nodeConfigMapVolumeMount = "node-config"
+	nodeTmp                 = "node-tmp"
 	nifiDataVolumeMount      = "nifi-data"
 
 	serverKeystoreVolume = "server-ks-files"

--- a/pkg/resources/nifi/pod.go
+++ b/pkg/resources/nifi/pod.go
@@ -85,12 +85,22 @@ func (r *Reconciler) pod(id int32, nodeConfig *v1alpha1.NodeConfig, pvcs []corev
 				},
 			},
 		},
+		{
+			Name: nodeTmp,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
 	}...)
 
 	podVolumeMounts := append(volumeMount, []corev1.VolumeMount{
 		{
 			Name:      nodeConfigMapVolumeMount,
 			MountPath: "/opt/nifi/nifi-current/tmp",
+		},
+		{
+			Name:      nodeTmp,
+			MountPath: "/tmp",
 		},
 	}...)
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR add an emptyDir volume for each node pods mounted into the `/tmp` folder

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

This should allow to deny error such as : 
```
 "description": "A library that was not part of the original container image was loaded. If an added library is loaded, this is a possible sign that an attacker has control of the workload and they are executing arbitrary code."
 "Added_Library_Fullpath": "/tmp/snappy-1.0.5-libsnappyjava.so"
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes