### PR TITLE
first draft

### DIFF
--- a/pkg/clientwrappers/accesspolicies/policies.go
+++ b/pkg/clientwrappers/accesspolicies/policies.go
@@ -1,6 +1,8 @@
 package accesspolicies
 
 import (
+	"strings"
+
 	"github.com/Orange-OpenSource/nifikop/api/v1alpha1"
 	"github.com/Orange-OpenSource/nifikop/pkg/clientwrappers"
 	"github.com/Orange-OpenSource/nifikop/pkg/common"
@@ -26,6 +28,18 @@ func ExistAccessPolicies(client client.Client, accessPolicy *v1alpha1.AccessPoli
 			return false, nil
 		}
 		return false, err
+	}
+
+	//special case: if the entity is not the same but e.g. the parent
+	//entity.Component.Resource = "/data/process-groups/d474577c-0178-1000-ffff-ffffeef1d529"
+	//accessPolicy.Resource = "/data"
+	//accessPolicy.ComponentType = "process-groups"
+	var gottenComponentId = strings.Replace(entity.Component.Resource, "/"+accessPolicy.ComponentType+"/", "", -1)
+	if string(accessPolicy.Resource) != "/" {
+		strings.Replace(entity.Component.Resource, string(accessPolicy.Resource), "", -1)
+	}
+	if accessPolicy.ComponentId != "" && gottenComponentId != accessPolicy.ComponentId {
+		return false, nil
 	}
 
 	return entity != nil, nil


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | ?
| Deprecations?   | no
| Related tickets | fixes #66
| License         | Apache 2.0


### What's in this PR?
First draft to fix setting permissions on componentId level.

### Additional context

#### Background info

When you try to get an accessPolicy by the name of the componentId from the nifi api you will get back the accessPolicy from its parent (and not null or empty) in case it has no accessPolicy yet.
(`entity, err := nClient.GetAccessPolicy(string(accessPolicy.Action), accessPolicy.GetResource(cluster))` in pkg/clientwrappers/accesspolicies/policies.go)
Then nifikop thinks the accessPolicy already exists and does not create it.
That's why I added more or less an if statment (componentID_from_nifi_api != componentID_from_nifiuser). Then the accessPolicy does not exist yet and needs to be created.

#### Requirements

- Create a processgroup in the nifi UI called "whatever". If you click on it you can see the id on the left side. In this example it is "e9c12f7e-0178-1000-0000-00007b03d420"

#### Example nifiuser CR

Here is an example to test a nifiuser including the edge case `resource: /` (adjust your `componentId`):
```
cat <<EOF | kubectl apply -f -
apiVersion: nifi.orange.com/v1alpha1
kind: NifiUser
metadata:
  name: default
spec:
  identity: user
  clusterRef:
    name: simplenifi
    namespace: default
  includeJKS: false
  createCert: false
  accessPolicies:
    - type: component
      action: write
      componentType: process-groups
      resource: /
      componentId: "e9c12f7e-0178-1000-0000-00007b03d420"
    - type: component
      action: write
      componentType: process-groups
      resource: /data
      componentId: "e9c12f7e-0178-1000-0000-00007b03d420"
EOF
```

#### Verify

In nifi UI under "User Policies" you can see now:
- "Component policy for process group whatever (write)"
- "Data policy for process group whatever (write)"

Without the fix no process group is mentioned under the "User Policies".

### Checklist

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [ ] Append changelog with changes

Sorry for the bad code. I tried to make it understandable.
What do you think about that behavior?
