### PR TITLE
possible fix for deleting nificluster including nifiusers

### DIFF
--- a/controllers/nificluster_controller.go
+++ b/controllers/nificluster_controller.go
@@ -18,8 +18,10 @@ package controllers
 
 import (
 	"context"
-	"emperror.dev/errors"
 	"fmt"
+	"time"
+
+	"emperror.dev/errors"
 	"github.com/Orange-OpenSource/nifikop/pkg/errorfactory"
 	"github.com/Orange-OpenSource/nifikop/pkg/k8sutil"
 	"github.com/Orange-OpenSource/nifikop/pkg/pki"
@@ -31,7 +33,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -205,7 +206,7 @@ func (r *NifiClusterReconciler) checkFinalizers(ctx context.Context,
 	var err error
 
 	var namespaces []string
-	if r.Namespaces == nil || len(r.Namespaces) == 0 {
+	if len(cluster.ObjectMeta.Namespace) == 0 {
 		// Fetch a list of all namespaces for DeleteAllOf requests
 		namespaces = make([]string, 0)
 		var namespaceList corev1.NamespaceList
@@ -216,8 +217,8 @@ func (r *NifiClusterReconciler) checkFinalizers(ctx context.Context,
 			namespaces = append(namespaces, ns.Name)
 		}
 	} else {
-		// use configured namespaces
-		namespaces = r.Namespaces
+		// use configured namespace
+		namespaces = append(namespaces, cluster.ObjectMeta.Namespace)
 	}
 
 	if cluster.Spec.ListenersConfig.SSLSecrets != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | ?
| Deprecations?   | no
| Related tickets | #105 and might be related to #103
| License         | Apache 2.0


### Why?
(I assume nifikop is namespace scoped and nifusers are in usage.)
While deleting nificluster, nifikop tries to get all namespaces and tries to delete nifiusers in all namespaces.
As far as I understand the nifiusers can only be within the same namespaces like the nificluster cr is located. So instead of using all namespaces we need to specify the namespace where the nificluster is located.

### What's in this PR?
I am not a developer and I dont understand all mechanism behind but I assume `cluster.ObjectMeta.Namespace` needs to be used in stead of `r.Namespaces`.
I tested it and it works as I expect.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [ ] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [ ] Append changelog with changes

### To Do
This bug seems small but has a big impact because once the nifkop is stuck, other nificlusters are not manageable anymore. So would be nice if you can take a look on it @erdrix 