### PR TITLE
[Fix/Operator] Change namespace watch configuration to manage single namespace deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed Bugs
 
+- [PR #109](https://github.com/Orange-OpenSource/nifikop/pull/109) - **[Operator/NifiCluster]** Change namespace watch configuration to manage single namespace deletion.
+
+
 ## v0.6.1
 
 ### Added

--- a/main.go
+++ b/main.go
@@ -92,16 +92,18 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "f1c5ece8.example.com",
-		Namespace:              watchNamespace, // namespaced-scope when the value is not an empty string
 	}
 
 	// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)
 	var namespaceList []string
-	if strings.Contains(watchNamespace, ",") {
+	if watchNamespace != "" {
 		setupLog.Info("manager set up with multiple namespaces", "namespaces", watchNamespace)
 		namespaceList = strings.Split(watchNamespace, ",")
+
+		for i := range namespaceList {
+			namespaceList[i] = strings.TrimSpace(namespaceList[i])
+		}
 		// configure cluster-scoped with MultiNamespacedCacheBuilder
-		options.Namespace = ""
 		options.NewCache = cache.MultiNamespacedCacheBuilder(namespaceList)
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #103 and #105
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Handles the case where only one namespace to monitor is specified as the case where more than one is listed.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


In the case of a single namespace, deleting the child resource did not work correctly (it acted as a cluster scope configuration). So this PR fix this issue.



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes
