### PR TITLE
[Feature/NiFiCluster] Additionals environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed Bugs
 
+- [PR #113](https://github.com/Orange-OpenSource/nifikop/pull/113) - **[Fix/NiFiDataflow]** Simple work around to avoid null pointer dereferencing on nifi side.
+
+
 ## v0.6.2
 
 ### Fixed Bugs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- [PR #114](https://github.com/Orange-OpenSource/nifikop/pull/114) - **[Fix/NiFiCluster]** Additionals environment variables.
+
 ### Changed
 
 ### Deprecated
@@ -11,7 +13,6 @@
 ### Fixed Bugs
 
 - [PR #113](https://github.com/Orange-OpenSource/nifikop/pull/113) - **[Fix/NiFiDataflow]** Simple work around to avoid null pointer dereferencing on nifi side.
-
 
 ## v0.6.2
 

--- a/api/v1alpha1/nificluster_types.go
+++ b/api/v1alpha1/nificluster_types.go
@@ -144,6 +144,9 @@ type Node struct {
 type ReadOnlyConfig struct {
 	// MaximumTimerDrivenThreadCount define the maximum number of threads for timer driven processors available to the system.
 	MaximumTimerDrivenThreadCount *int32 `json:"maximumTimerDrivenThreadCount,omitempty"`
+	// AdditionalSharedEnvs define a set of additional env variables that will shared between all init containers and
+	// containers in the pod.
+	AdditionalSharedEnvs []corev1.EnvVar `json:"additionalSharedEnvs,omitempty"`
 	// NifiProperties configuration that will be applied to the node.
 	NifiProperties NifiProperties `json:"nifiProperties,omitempty"`
 	// ZookeeperProperties configuration that will be applied to the node.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1248,6 +1248,13 @@ func (in *ReadOnlyConfig) DeepCopyInto(out *ReadOnlyConfig) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.AdditionalSharedEnvs != nil {
+		in, out := &in.AdditionalSharedEnvs, &out.AdditionalSharedEnvs
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.NifiProperties.DeepCopyInto(&out.NifiProperties)
 	in.ZookeeperProperties.DeepCopyInto(&out.ZookeeperProperties)
 	in.BootstrapProperties.DeepCopyInto(&out.BootstrapProperties)

--- a/config/crd/bases/nifi.orange.com_nificlusters.yaml
+++ b/config/crd/bases/nifi.orange.com_nificlusters.yaml
@@ -2437,6 +2437,121 @@ spec:
                         which has type read-only these config changes will trigger
                         rolling upgrade
                       properties:
+                        additionalSharedEnvs:
+                          description: AdditionalSharedEnvs define a set of additional
+                            env variables that will shared between all init containers
+                            and containers in the pod.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
                         bootstrapNotificationServicesConfig:
                           description: BootstrapNotificationServices configuration
                             that will be applied to the node.
@@ -2739,6 +2854,117 @@ spec:
                   cluster wide, all theses will be merged with node specified readOnly
                   configurations, so it can be overwritten per node.
                 properties:
+                  additionalSharedEnvs:
+                    description: AdditionalSharedEnvs define a set of additional env
+                      variables that will shared between all init containers and containers
+                      in the pod.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   bootstrapNotificationServicesConfig:
                     description: BootstrapNotificationServices configuration that
                       will be applied to the node.

--- a/pkg/resources/nifi/pod.go
+++ b/pkg/resources/nifi/pod.go
@@ -144,7 +144,7 @@ func (r *Reconciler) pod(id int32, nodeConfig *v1alpha1.NodeConfig, pvcs []corev
 				RunAsNonRoot: func(b bool) *bool { return &b }(true),
 				FSGroup:      nodeConfig.GetFSGroup(),
 			},
-			InitContainers: append(initContainers, []corev1.Container{
+			InitContainers: r.injectAdditionalEnvVars(append(initContainers, []corev1.Container{
 				{
 					Name:            "zookeeper",
 					Image:           r.NifiCluster.Spec.GetInitContainerImage(),
@@ -158,11 +158,11 @@ done`,
 						zkAddress, zkHostname, zkPort)},
 					Resources: generateInitContainerResources(),
 				},
-			}...),
+			}...)),
 			Affinity: &corev1.Affinity{
 				PodAntiAffinity: generatePodAntiAffinity(r.NifiCluster.Name, r.NifiCluster.Spec.OneNifiNodePerNode),
 			},
-			Containers:                    r.generateContainers(nodeConfig, id, podVolumeMounts, zkAddress),
+			Containers:                    r.injectAdditionalEnvVars(r.generateContainers(nodeConfig, id, podVolumeMounts, zkAddress)),
 			Volumes:                       podVolumes,
 			RestartPolicy:                 corev1.RestartPolicyNever,
 			TerminationGracePeriodSeconds: util.Int64Pointer(120),
@@ -518,4 +518,14 @@ exec bin/nifi.sh run`, resolveIp, removesFileAction)}
 		VolumeMounts: podVolumeMounts,
 		Resources:    *nodeConfig.GetResources(),
 	}
+}
+
+
+func (r *Reconciler) injectAdditionalEnvVars(containers []corev1.Container)  (injectedContainers []corev1.Container) {
+
+	for _, container := range containers {
+		container.Env = append(container.Env, r.NifiCluster.Spec.ReadOnlyConfig.AdditionalSharedEnvs...)
+		injectedContainers = append(injectedContainers, container)
+	}
+	return
 }

--- a/pkg/resources/nifi/pod.go
+++ b/pkg/resources/nifi/pod.go
@@ -520,8 +520,7 @@ exec bin/nifi.sh run`, resolveIp, removesFileAction)}
 	}
 }
 
-
-func (r *Reconciler) injectAdditionalEnvVars(containers []corev1.Container)  (injectedContainers []corev1.Container) {
+func (r *Reconciler) injectAdditionalEnvVars(containers []corev1.Container) (injectedContainers []corev1.Container) {
 
 	for _, container := range containers {
 		container.Env = append(container.Env, r.NifiCluster.Spec.ReadOnlyConfig.AdditionalSharedEnvs...)

--- a/site/docs/5_references/1_nifi_cluster/2_read_only_config.md
+++ b/site/docs/5_references/1_nifi_cluster/2_read_only_config.md
@@ -124,11 +124,14 @@ readOnlyConfig:
 |Field|Type|Description|Required|Default|
 |-----|----|-----------|--------|--------|
 |maximumTimerDrivenThreadCount|int32|define the maximum number of threads for timer driven processors available to the system.|No|nil|
+|additionalSharedEnvs|\[ \][corev1.EnvVar](https://pkg.go.dev/k8s.io/api/core/v1#EnvVar)|define a set of additional env variables that will shared between all init containers and ontainers in the pod..|No|\[ \]|
 |nifiProperties|[NifiProperties](#nifiproperties)|nifi.properties configuration that will be applied to the node.|No|nil|
 |zookeeperProperties|[ZookeeperProperties](#zookeeperproperties)|zookeeper.properties configuration that will be applied to the node.|No|nil|
 |bootstrapProperties|[BootstrapProperties](#bootstrapproperties)|bootstrap.conf configuration that will be applied to the node.|No|nil|
 |logbackConfig|[LogbackConfig](#logbackconfig)|logback.xml configuration that will be applied to the node.|No|nil|
 |bootstrapNotificationServicesConfig|[BootstrapNotificationServices](#bootstrapnotificationservices)|bootstrap_notification_services.xml configuration that will be applied to the node.|No|nil|
+
+
 
 ## NifiProperties
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

It adds a new field `NifiCluster.Spec.ReadOnlyConfig.additionalSharedEnvs` that allows to pass a list of [corev1.EnvVar](https://pkg.go.dev/k8s.io/api/core/v1#EnvVar) to all containers (init included) in the NiFi's node pods.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

It gives the ability to extend default environment variables managed by the operator.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog with changes