### PR TITLE
corrected typo in the nifi configmap for bootstrap-notification-servi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,7 +253,7 @@ ZooKeeper.
 - Implement pod management lifecycle
 - Implement Graceful downscale pod lifecycle management
 - Implement Graceful upscale pod lifecycle management
-- Implement configuration lifecycle management for : nifi.properties, zookeeper.properties, state-management.xml, login-identity-providers.xml, logback.xml, bootstrap.conf, bootstrap-notification-servces.xml
+- Implement configuration lifecycle management for : nifi.properties, zookeeper.properties, state-management.xml, login-identity-providers.xml, logback.xml, bootstrap.conf, bootstrap-notification-services.xml
 - Initiate documentations
 - Implementation basic makefile for some actions (debug, build, deploy, run, push, unit-test)
 - Create helm chart for operator

--- a/pkg/resources/nifi/configmap.go
+++ b/pkg/resources/nifi/configmap.go
@@ -52,13 +52,13 @@ func (r *Reconciler) configMap(id int32, nodeConfig *v1alpha1.NodeConfig, server
 			r.NifiCluster,
 		),
 		Data: map[string][]byte{
-			"nifi.properties":                    []byte(r.generateNifiPropertiesNodeConfig(id, nodeConfig, serverPass, clientPass, superUsers, log)),
-			"zookeeper.properties":               []byte(r.generateZookeeperPropertiesNodeConfig(id, nodeConfig, log)),
-			"state-management.xml":               []byte(r.getStateManagementConfigString(nodeConfig, id, log)),
-			"login-identity-providers.xml":       []byte(r.getLoginIdentityProvidersConfigString(nodeConfig, id, log)),
-			"logback.xml":                        []byte(r.getLogbackConfigString(nodeConfig, id, log)),
-			"bootstrap.conf":                     []byte(r.generateBootstrapPropertiesNodeConfig(id, nodeConfig, log)),
-			"bootstrap-notification-servces.xml": []byte(r.getBootstrapNotificationServicesConfigString(nodeConfig, id, log)),
+			"nifi.properties":                     []byte(r.generateNifiPropertiesNodeConfig(id, nodeConfig, serverPass, clientPass, superUsers, log)),
+			"zookeeper.properties":                []byte(r.generateZookeeperPropertiesNodeConfig(id, nodeConfig, log)),
+			"state-management.xml":                []byte(r.getStateManagementConfigString(nodeConfig, id, log)),
+			"login-identity-providers.xml":        []byte(r.getLoginIdentityProvidersConfigString(nodeConfig, id, log)),
+			"logback.xml":                         []byte(r.getLogbackConfigString(nodeConfig, id, log)),
+			"bootstrap.conf":                      []byte(r.generateBootstrapPropertiesNodeConfig(id, nodeConfig, log)),
+			"bootstrap-notification-services.xml": []byte(r.getBootstrapNotificationServicesConfigString(nodeConfig, id, log)),
 		},
 	}
 


### PR DESCRIPTION
…ces.xml

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no, this configmap key is never looked up by its value
| Deprecations?   | no
| Related tickets | fixes #127
| License         | Apache 2.0


### What's in this PR?
Simple one-liner to correct the name of the bootstrap-notification-services.xml file that gets laid down into the running nifi pod so nifi correctly picks it up.


### Why?
NiFi isn't currently reading this file since it doesn't match the file name in the related configuration property.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes