### PR TITLE
Support --namespace helm arg

### DIFF
--- a/helm/nifikop/templates/deployment.yaml
+++ b/helm/nifikop/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "nifikop.fullname" . }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     app: {{ template "nifikop.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/helm/nifikop/templates/service.yaml
+++ b/helm/nifikop/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "nifikop.name" . }}-metrics
+  namespace: {{ $.Release.Namespace }}
   labels:
     component: app
     app: {{ template "nifikop.name" . }}-metrics

--- a/helm/nifikop/templates/service_account.yaml
+++ b/helm/nifikop/templates/service_account.yaml
@@ -9,6 +9,7 @@ metadata:
     release: {{ .Release.Name }}
   {{- if and .Values.serviceAccount .Values.serviceAccount.name}}
   name: {{ .Values.serviceAccount.name }}      
+  namespace: {{ $.Release.Namespace }}
   {{- else }}
   name: {{ template "nifikop.name" . }}
   {{- end }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | nos
| Deprecations?   | nos
| Related tickets | None
| License         | Apache 2.0


### What's in this PR?
Adds support for `--namespace` helm argument to specify which ns to create objects in.

### Why?
When installing this chart, it would be nice to be able to specify `--namespace somens` and have the objects put in the right namespace instead of always relying on the kube client being pointing at the correct ns.



### Additional context
I don't actually know much about helm or if this is the correct way to do this.


### Checklist

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [ ] User guide and development docs updated (if needed)
- [ ] Append changelog with changes

### To Do
- [ ] Someone smarter than me should test this