### PR TITLE
[Fix] Nil pointer exception on empty description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed Bugs
 
 - [PR #167](https://github.com/Orange-OpenSource/nifikop/pull/167) - **[Operator/NiFiDataflow]** Fix nil pointer exception case whe sync Dataflow.
+- [PR #189](https://github.com/Orange-OpenSource/nifikop/pull/189) - **[Operator/NiFiParameterContext]** Fix nil pointer exception case on empty description.
 
 ## v0.7.5
 

--- a/pkg/clientwrappers/parametercontext/parametercontext.go
+++ b/pkg/clientwrappers/parametercontext/parametercontext.go
@@ -154,7 +154,9 @@ func parameterContextIsSync(
 					!((expected.Parameter.Value == nil && param.Parameter.Value == nil) ||
 						((expected.Parameter.Value != nil && param.Parameter.Value != nil) &&
 							(*expected.Parameter.Value == *param.Parameter.Value)))) ||
-					*expected.Parameter.Description != *param.Parameter.Description {
+					!((expected.Parameter.Description == nil || *expected.Parameter.Description == "") &&
+						((param.Parameter.Description == nil || *param.Parameter.Description == "") ||
+							(expected.Parameter.Description == param.Parameter.Description))) {
 
 					return false
 				}
@@ -203,7 +205,9 @@ func updateRequestPrepare(
 					!((expected.Parameter.Value == nil && param.Parameter.Value == nil) ||
 						((expected.Parameter.Value != nil && param.Parameter.Value != nil) &&
 							(*expected.Parameter.Value == *param.Parameter.Value)))) ||
-					*expected.Parameter.Description != *param.Parameter.Description {
+					!((expected.Parameter.Description == nil || *expected.Parameter.Description == "") &&
+						((param.Parameter.Description == nil || *param.Parameter.Description == "") ||
+							(expected.Parameter.Description == param.Parameter.Description))) {
 					notFound = false
 					if expected.Parameter.Value == nil && param.Parameter.Value != nil {
 						toRemove = append(toRemove, expected.Parameter.Name)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Improve condition on parameter update checking with the consideration of nil description.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
On some cases, when the description is empty, NiFi will return a null value for the parameter description. This null value will be interpreted as a nil value in the operator. This interpretation makes the operator crash.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes