### PR TITLE
Add event on registry client reference error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### Added
 
+- [PR #191](https://github.com/Orange-OpenSource/nifikop/pull/191) - **[Operator/NiFiDataflow]** Add event on registry client reference error.
+
 ### Changed
+
+- [PR #188](https://github.com/Orange-OpenSource/nifikop/pull/188) - **[Operator/NiFiCluster]** Support all pod status as terminating if the pod phase is `failed`.
 
 ### Deprecated
 
@@ -11,7 +15,6 @@
 ### Fixed Bugs
 
 - [PR #167](https://github.com/Orange-OpenSource/nifikop/pull/167) - **[Operator/NiFiDataflow]** Fix nil pointer exception case whe sync Dataflow.
-- [PR #188](https://github.com/Orange-OpenSource/nifikop/pull/188) - **[Operator/NiFiCluster]** Support all pod status as terminating if the pod phase is `failed`.
 - [PR #189](https://github.com/Orange-OpenSource/nifikop/pull/189) - **[Operator/NiFiParameterContext]** Fix nil pointer exception case on empty description.
 
 ## v0.7.5

--- a/controllers/nifidataflow_controller.go
+++ b/controllers/nifidataflow_controller.go
@@ -18,9 +18,13 @@ package controllers
 
 import (
 	"context"
-	"emperror.dev/errors"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"strconv"
+	"time"
+
+	"emperror.dev/errors"
 	"github.com/Orange-OpenSource/nifikop/pkg/clientwrappers/dataflow"
 	"github.com/Orange-OpenSource/nifikop/pkg/errorfactory"
 	"github.com/Orange-OpenSource/nifikop/pkg/k8sutil"
@@ -31,10 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"strconv"
-	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -126,6 +127,9 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			}
 
 			// the cluster does not exist - should have been caught pre-flight
+			r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceRegistryClientError",
+				fmt.Sprintf("Failed to lookup reference registry client : %s in %s",
+					current.Spec.RegistryClientRef.Name, registryClientNamespace))
 			return RequeueWithError(r.Log, "failed to lookup referenced registry client", err)
 		}
 	}

--- a/controllers/nifidataflow_controller.go
+++ b/controllers/nifidataflow_controller.go
@@ -126,10 +126,11 @@ func (r *NifiDataflowReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				return Reconciled()
 			}
 
-			// the cluster does not exist - should have been caught pre-flight
 			r.Recorder.Event(instance, corev1.EventTypeWarning, "ReferenceRegistryClientError",
 				fmt.Sprintf("Failed to lookup reference registry client : %s in %s",
 					current.Spec.RegistryClientRef.Name, registryClientNamespace))
+
+			// the cluster does not exist - should have been caught pre-flight
 			return RequeueWithError(r.Log, "failed to lookup referenced registry client", err)
 		}
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add an event to notify that there is an error with the registry client reference.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Because without this event, there is no indication of why the dataflow is not deployed.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes