### PR TITLE
keep Helm chart CRDs in line with baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed Bugs
 
+- [PR #197](https://github.com/Orange-OpenSource/nifikop/pull/197) - **[Operator/NiFiDataflow]** Keep Helm chart CRDs inline with baseline.
+
 ## v0.7.6
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ generate: controller-gen
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases output:crd:artifacts:config=helm/nifikop/crds
 
 # Build the docker image
 docker-build:

--- a/helm/nifikop/crds/nifi.orange.com_nificlusters.yaml
+++ b/helm/nifikop/crds/nifi.orange.com_nificlusters.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -15,3300 +16,218 @@ spec:
     singular: nificluster
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: NifiCluster is the Schema for the nificlusters API
-          properties:
-            apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
-              type: string
-            kind:
-              description:
-                "Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: NifiClusterSpec defines the desired state of NifiCluster
-              properties:
-                clientType:
-                  description:
-                    clientType defines if the operator will use basic or
-                    tls authentication to query the NiFi cluster.
-                  enum:
-                    - tls
-                    - basic
-                  type: string
-                clusterImage:
-                  description:
-                    clusterImage can specify the whole NiFi cluster image
-                    in one place
-                  type: string
-                disruptionBudget:
-                  description: Defines the configuration for PodDisruptionBudget
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NifiCluster is the Schema for the nificlusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NifiClusterSpec defines the desired state of NifiCluster
+            properties:
+              clientType:
+                description: clientType defines if the operator will use basic or
+                  tls authentication to query the NiFi cluster.
+                enum:
+                - tls
+                - basic
+                type: string
+              clusterImage:
+                description: clusterImage can specify the whole NiFi cluster image
+                  in one place
+                type: string
+              disruptionBudget:
+                description: Defines the configuration for PodDisruptionBudget
+                properties:
+                  budget:
+                    description: The budget to set for the PDB, can either be static
+                      number or a percentage
+                    pattern: ^[0-9]+$|^[0-9]{1,2}%$|^100%$
+                    type: string
+                  create:
+                    description: If set to true, will create a podDisruptionBudget
+                    type: boolean
+                type: object
+              externalServices:
+                description: ExternalService specifies settings required to access
+                  nifi externally
+                items:
                   properties:
-                    budget:
-                      description:
-                        The budget to set for the PDB, can either be static
-                        number or a percentage
-                      pattern: ^[0-9]+$|^[0-9]{1,2}%$|^100%$
+                    name:
+                      description: 'Name must be unique within a namespace. Is required
+                        when creating resources, although some resources may allow
+                        a client to request the generation of an appropriate name
+                        automatically. Name is primarily intended for creation idempotence
+                        and configuration definition. Cannot be updated. More info:
+                        http://kubernetes.io/docs/user-guide/identifiers#names'
                       type: string
-                    create:
-                      description: If set to true, will create a podDisruptionBudget
-                      type: boolean
-                  type: object
-                externalServices:
-                  description:
-                    ExternalService specifies settings required to access
-                    nifi externally
-                  items:
-                    properties:
-                      name:
-                        description:
-                          "Name must be unique within a namespace. Is required
-                          when creating resources, although some resources may allow
-                          a client to request the generation of an appropriate name
-                          automatically. Name is primarily intended for creation idempotence
-                          and configuration definition. Cannot be updated. More info:
-                          http://kubernetes.io/docs/user-guide/identifiers#names"
-                        type: string
-                      serviceAnnotations:
-                        additionalProperties:
-                          type: string
-                        description:
-                          "Annotations is an unstructured key value map stored
-                          with a resource that may be set by external tools to store
-                          and retrieve arbitrary metadata. They are not queryable and
-                          should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations"
-                        type: object
-                      spec:
-                        description: Spec defines the behavior of a service.
-                        properties:
-                          clusterIP:
-                            description:
-                              'clusterIP is the IP address of the service
-                              and is usually assigned randomly by the master. If an
-                              address is specified manually and is not in use by others,
-                              it will be allocated to the service; otherwise, creation
-                              of the service will fail. This field can not be changed
-                              through updates. Valid values are "None", empty string
-                              (""), or a valid IP address. "None" can be specified for
-                              headless services when proxying is not required. Only
-                              applies to types ClusterIP, NodePort, and LoadBalancer.
-                              Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                            type: string
-                          externalIPs:
-                            description:
-                              externalIPs is a list of IP addresses for which
-                              nodes in the cluster will also accept traffic for this
-                              service.  These IPs are not managed by Kubernetes.  The
-                              user is responsible for ensuring that traffic arrives
-                              at a node with this IP.  A common example is external
-                              load-balancers that are not part of the Kubernetes system.
-                            items:
-                              type: string
-                            type: array
-                          externalName:
-                            description:
-                              externalName is the external reference that
-                              kubedns or equivalent will return as a CNAME record for
-                              this service. No proxying will be involved. Must be a
-                              valid RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
-                              and requires Type to be ExternalName.
-                            type: string
-                          loadBalancerIP:
-                            description:
-                              "Only applies to Service Type: LoadBalancer
-                              LoadBalancer will get created with the IP specified in
-                              this field. This feature depends on whether the underlying
-                              cloud-provider supports specifying the loadBalancerIP
-                              when a load balancer is created. This field will be ignored
-                              if the cloud-provider does not support the feature."
-                            type: string
-                          loadBalancerSourceRanges:
-                            description:
-                              'If specified and supported by the platform,
-                              this will restrict traffic through the cloud-provider
-                              load-balancer will be restricted to the specified client
-                              IPs. This field will be ignored if the cloud-provider
-                              does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
-                            items:
-                              type: string
-                            type: array
-                          portConfigs:
-                            description:
-                              Contains the list port for the service and
-                              the associated listener
-                            items:
-                              properties:
-                                internalListenerName:
-                                  description:
-                                    The name of the listener which will be
-                                    used as target container.
-                                  type: string
-                                port:
-                                  description:
-                                    The port that will be exposed by this
-                                    service.
-                                  format: int32
-                                  type: integer
-                              required:
-                                - internalListenerName
-                                - port
-                              type: object
-                            type: array
-                          type:
-                            description:
-                              'type determines how the Service is exposed.
-                              Defaults to ClusterIP. Valid options are ExternalName,
-                              ClusterIP, NodePort, and LoadBalancer. "ExternalName"
-                              maps to the specified externalName. "ClusterIP" allocates
-                              a cluster-internal IP address for load-balancing to endpoints.
-                              Endpoints are determined by the selector or if that is
-                              not specified, by manual construction of an Endpoints
-                              object. If clusterIP is "None", no virtual IP is allocated
-                              and the endpoints are published as a set of endpoints
-                              rather than a stable IP. "NodePort" builds on ClusterIP
-                              and allocates a port on every node which routes to the
-                              clusterIP. "LoadBalancer" builds on NodePort and creates
-                              an external load-balancer (if supported in the current
-                              cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                            type: string
-                        required:
-                          - portConfigs
-                        type: object
-                    required:
-                      - spec
-                    type: object
-                  type: array
-                initContainerImage:
-                  description:
-                    initContainerImage can override the default image used
-                    into the init container to check if ZoooKeeper server is reachable.
-                  type: string
-                initContainers:
-                  description: initContainers defines additional initContainers configurations
-                  items:
-                    description:
-                      A single application container that you want to run
-                      within a pod.
-                    properties:
-                      args:
-                        description:
-                          "Arguments to the entrypoint. The docker image's
-                          CMD is used if this is not provided. Variable references $(VAR_NAME)
-                          are expanded using the container's environment. If a variable
-                          cannot be resolved, the reference in the input string will
-                          be unchanged. The $(VAR_NAME) syntax can be escaped with a
-                          double $$, ie: $$(VAR_NAME). Escaped references will never
-                          be expanded, regardless of whether the variable exists or
-                          not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell"
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        description:
-                          "Entrypoint array. Not executed within a shell.
-                          The docker image's ENTRYPOINT is used if this is not provided.
-                          Variable references $(VAR_NAME) are expanded using the container's
-                          environment. If a variable cannot be resolved, the reference
-                          in the input string will be unchanged. The $(VAR_NAME) syntax
-                          can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
-                          references will never be expanded, regardless of whether the
-                          variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell"
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        description:
-                          List of environment variables to set in the container.
-                          Cannot be updated.
-                        items:
-                          description:
-                            EnvVar represents an environment variable present
-                            in a Container.
-                          properties:
-                            name:
-                              description:
-                                Name of the environment variable. Must be
-                                a C_IDENTIFIER.
-                              type: string
-                            value:
-                              description:
-                                'Variable references $(VAR_NAME) are expanded
-                                using the previous defined environment variables in
-                                the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in the
-                                input string will be unchanged. The $(VAR_NAME) syntax
-                                can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
-                                references will never be expanded, regardless of whether
-                                the variable exists or not. Defaults to "".'
-                              type: string
-                            valueFrom:
-                              description:
-                                Source for the environment variable's value.
-                                Cannot be used if value is not empty.
-                              properties:
-                                configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
-                                  properties:
-                                    key:
-                                      description: The key to select.
-                                      type: string
-                                    name:
-                                      description:
-                                        "Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind,
-                                        uid?"
-                                      type: string
-                                    optional:
-                                      description:
-                                        Specify whether the ConfigMap or
-                                        its key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                                fieldRef:
-                                  description:
-                                    "Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels['<KEY>']`,
-                                    `metadata.annotations['<KEY>']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs."
-                                  properties:
-                                    apiVersion:
-                                      description:
-                                        Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
-                                      type: string
-                                    fieldPath:
-                                      description:
-                                        Path of the field to select in the
-                                        specified API version.
-                                      type: string
-                                  required:
-                                    - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  description:
-                                    "Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported."
-                                  properties:
-                                    containerName:
-                                      description:
-                                        "Container name: required for volumes,
-                                        optional for env vars"
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      description:
-                                        Specifies the output format of the
-                                        exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      description: "Required: resource to select"
-                                      type: string
-                                  required:
-                                    - resource
-                                  type: object
-                                secretKeyRef:
-                                  description:
-                                    Selects a key of a secret in the pod's
-                                    namespace
-                                  properties:
-                                    key:
-                                      description:
-                                        The key of the secret to select from.  Must
-                                        be a valid secret key.
-                                      type: string
-                                    name:
-                                      description:
-                                        "Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind,
-                                        uid?"
-                                      type: string
-                                    optional:
-                                      description:
-                                        Specify whether the Secret or its
-                                        key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                              type: object
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      envFrom:
-                        description:
-                          List of sources to populate environment variables
-                          in the container. The keys defined within a source must be
-                          a C_IDENTIFIER. All invalid keys will be reported as an event
-                          when the container is starting. When a key exists in multiple
-                          sources, the value associated with the last source will take
-                          precedence. Values defined by an Env with a duplicate key
-                          will take precedence. Cannot be updated.
-                        items:
-                          description:
-                            EnvFromSource represents the source of a set
-                            of ConfigMaps
-                          properties:
-                            configMapRef:
-                              description: The ConfigMap to select from
-                              properties:
-                                name:
-                                  description:
-                                    "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?"
-                                  type: string
-                                optional:
-                                  description:
-                                    Specify whether the ConfigMap must be
-                                    defined
-                                  type: boolean
-                              type: object
-                            prefix:
-                              description:
-                                An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
-                              type: string
-                            secretRef:
-                              description: The Secret to select from
-                              properties:
-                                name:
-                                  description:
-                                    "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?"
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret must be defined
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        description:
-                          "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                          This field is optional to allow higher level config management
-                          to default or override container images in workload controllers
-                          like Deployments and StatefulSets."
-                        type: string
-                      imagePullPolicy:
-                        description:
-                          "Image pull policy. One of Always, Never, IfNotPresent.
-                          Defaults to Always if :latest tag is specified, or IfNotPresent
-                          otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images"
-                        type: string
-                      lifecycle:
-                        description:
-                          Actions that the management system should take
-                          in response to container lifecycle events. Cannot be updated.
-                        properties:
-                          postStart:
-                            description:
-                              "PostStart is called immediately after a container
-                              is created. If the handler fails, the container is terminated
-                              and restarted according to its restart policy. Other management
-                              of the container blocks until the hook completes. More
-                              info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks"
-                            properties:
-                              exec:
-                                description:
-                                  One and only one of the following should
-                                  be specified. Exec specifies the action to take.
-                                properties:
-                                  command:
-                                    description:
-                                      Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                description: HTTPGet specifies the http request to perform.
-                                properties:
-                                  host:
-                                    description:
-                                      Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
-                                    type: string
-                                  httpHeaders:
-                                    description:
-                                      Custom headers to set in the request.
-                                      HTTP allows repeated headers.
-                                    items:
-                                      description:
-                                        HTTPHeader describes a custom header
-                                        to be used in HTTP probes
-                                      properties:
-                                        name:
-                                          description: The header field name
-                                          type: string
-                                        value:
-                                          description: The header field value
-                                          type: string
-                                      required:
-                                        - name
-                                        - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    description: Path to access on the HTTP server.
-                                    type: string
-                                  port:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description:
-                                      Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    description:
-                                      Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
-                                    type: string
-                                required:
-                                  - port
-                                type: object
-                              tcpSocket:
-                                description:
-                                  "TCPSocket specifies an action involving
-                                  a TCP port. TCP hooks not yet supported TODO: implement
-                                  a realistic TCP lifecycle hook"
-                                properties:
-                                  host:
-                                    description:
-                                      "Optional: Host name to connect to,
-                                      defaults to the pod IP."
-                                    type: string
-                                  port:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description:
-                                      Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                  - port
-                                type: object
-                            type: object
-                          preStop:
-                            description:
-                              "PreStop is called immediately before a container
-                              is terminated due to an API request or management event
-                              such as liveness/startup probe failure, preemption, resource
-                              contention, etc. The handler is not called if the container
-                              crashes or exits. The reason for termination is passed
-                              to the handler. The Pod's termination grace period countdown
-                              begins before the PreStop hooked is executed. Regardless
-                              of the outcome of the handler, the container will eventually
-                              terminate within the Pod's termination grace period.
-                              Other management of the container blocks until the hook
-                              completes or until the termination grace period is reached.
-                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks"
-                            properties:
-                              exec:
-                                description:
-                                  One and only one of the following should
-                                  be specified. Exec specifies the action to take.
-                                properties:
-                                  command:
-                                    description:
-                                      Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                description: HTTPGet specifies the http request to perform.
-                                properties:
-                                  host:
-                                    description:
-                                      Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
-                                    type: string
-                                  httpHeaders:
-                                    description:
-                                      Custom headers to set in the request.
-                                      HTTP allows repeated headers.
-                                    items:
-                                      description:
-                                        HTTPHeader describes a custom header
-                                        to be used in HTTP probes
-                                      properties:
-                                        name:
-                                          description: The header field name
-                                          type: string
-                                        value:
-                                          description: The header field value
-                                          type: string
-                                      required:
-                                        - name
-                                        - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    description: Path to access on the HTTP server.
-                                    type: string
-                                  port:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description:
-                                      Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    description:
-                                      Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
-                                    type: string
-                                required:
-                                  - port
-                                type: object
-                              tcpSocket:
-                                description:
-                                  "TCPSocket specifies an action involving
-                                  a TCP port. TCP hooks not yet supported TODO: implement
-                                  a realistic TCP lifecycle hook"
-                                properties:
-                                  host:
-                                    description:
-                                      "Optional: Host name to connect to,
-                                      defaults to the pod IP."
-                                    type: string
-                                  port:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description:
-                                      Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                  - port
-                                type: object
-                            type: object
-                        type: object
-                      livenessProbe:
-                        description:
-                          "Periodic probe of container liveness. Container
-                          will be restarted if the probe fails. Cannot be updated. More
-                          info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                        properties:
-                          exec:
-                            description:
-                              One and only one of the following should be
-                              specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description:
-                                  Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description:
-                              Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description:
-                                  Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description:
-                                  Custom headers to set in the request. HTTP
-                                  allows repeated headers.
-                                items:
-                                  description:
-                                    HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description:
-                                  Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description:
-                                  Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description:
-                              "Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description:
-                              How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description:
-                              Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description:
-                              "TCPSocket specifies an action involving a
-                              TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook"
-                            properties:
-                              host:
-                                description:
-                                  "Optional: Host name to connect to, defaults
-                                  to the pod IP."
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description:
-                                  Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description:
-                              "Number of seconds after which the probe times
-                              out. Defaults to 1 second. Minimum value is 1. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        description:
-                          Name of the container specified as a DNS_LABEL.
-                          Each container in a pod must have a unique name (DNS_LABEL).
-                          Cannot be updated.
-                        type: string
-                      ports:
-                        description:
-                          List of ports to expose from the container. Exposing
-                          a port here gives the system additional information about
-                          the network connections a container uses, but is primarily
-                          informational. Not specifying a port here DOES NOT prevent
-                          that port from being exposed. Any port which is listening
-                          on the default "0.0.0.0" address inside a container will be
-                          accessible from the network. Cannot be updated.
-                        items:
-                          description:
-                            ContainerPort represents a network port in a
-                            single container.
-                          properties:
-                            containerPort:
-                              description:
-                                Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x < 65536.
-                              format: int32
-                              type: integer
-                            hostIP:
-                              description: What host IP to bind the external port to.
-                              type: string
-                            hostPort:
-                              description:
-                                Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x <
-                                65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
-                              format: int32
-                              type: integer
-                            name:
-                              description:
-                                If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
-                              type: string
-                            protocol:
-                              default: TCP
-                              description:
-                                Protocol for port. Must be UDP, TCP, or SCTP.
-                                Defaults to "TCP".
-                              type: string
-                          required:
-                            - containerPort
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                          - containerPort
-                          - protocol
-                        x-kubernetes-list-type: map
-                      readinessProbe:
-                        description:
-                          "Periodic probe of container service readiness.
-                          Container will be removed from service endpoints if the probe
-                          fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                        properties:
-                          exec:
-                            description:
-                              One and only one of the following should be
-                              specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description:
-                                  Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description:
-                              Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description:
-                                  Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description:
-                                  Custom headers to set in the request. HTTP
-                                  allows repeated headers.
-                                items:
-                                  description:
-                                    HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description:
-                                  Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description:
-                                  Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description:
-                              "Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description:
-                              How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description:
-                              Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description:
-                              "TCPSocket specifies an action involving a
-                              TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook"
-                            properties:
-                              host:
-                                description:
-                                  "Optional: Host name to connect to, defaults
-                                  to the pod IP."
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description:
-                                  Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description:
-                              "Number of seconds after which the probe times
-                              out. Defaults to 1 second. Minimum value is 1. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        description:
-                          "Compute Resources required by this container.
-                          Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description:
-                              "Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description:
-                              "Requests describes the minimum amount of compute
-                              resources required. If Requests is omitted for a container,
-                              it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. More info:
-                              https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
-                            type: object
-                        type: object
-                      securityContext:
-                        description:
-                          "Security options the pod should run with. More
-                          info: https://kubernetes.io/docs/concepts/policy/security-context/
-                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
-                        properties:
-                          allowPrivilegeEscalation:
-                            description:
-                              "AllowPrivilegeEscalation controls whether
-                              a process can gain more privileges than its parent process.
-                              This bool directly controls if the no_new_privs flag will
-                              be set on the container process. AllowPrivilegeEscalation
-                              is true always when the container is: 1) run as Privileged
-                              2) has CAP_SYS_ADMIN"
-                            type: boolean
-                          capabilities:
-                            description:
-                              The capabilities to add/drop when running containers.
-                              Defaults to the default set of capabilities granted by
-                              the container runtime.
-                            properties:
-                              add:
-                                description: Added capabilities
-                                items:
-                                  description:
-                                    Capability represent POSIX capabilities
-                                    type
-                                  type: string
-                                type: array
-                              drop:
-                                description: Removed capabilities
-                                items:
-                                  description:
-                                    Capability represent POSIX capabilities
-                                    type
-                                  type: string
-                                type: array
-                            type: object
-                          privileged:
-                            description:
-                              Run container in privileged mode. Processes
-                              in privileged containers are essentially equivalent to
-                              root on the host. Defaults to false.
-                            type: boolean
-                          procMount:
-                            description:
-                              procMount denotes the type of proc mount to
-                              use for the containers. The default is DefaultProcMount
-                              which uses the container runtime defaults for readonly
-                              paths and masked paths. This requires the ProcMountType
-                              feature flag to be enabled.
-                            type: string
-                          readOnlyRootFilesystem:
-                            description:
-                              Whether this container has a read-only root
-                              filesystem. Default is false.
-                            type: boolean
-                          runAsGroup:
-                            description:
-                              The GID to run the entrypoint of the container
-                              process. Uses runtime default if unset. May also be set
-                              in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence.
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
-                            description:
-                              Indicates that the container must run as a
-                              non-root user. If true, the Kubelet will validate the
-                              image at runtime to ensure that it does not run as UID
-                              0 (root) and fail to start the container if it does. If
-                              unset or false, no such validation will be performed.
-                              May also be set in PodSecurityContext.  If set in both
-                              SecurityContext and PodSecurityContext, the value specified
-                              in SecurityContext takes precedence.
-                            type: boolean
-                          runAsUser:
-                            description:
-                              The UID to run the entrypoint of the container
-                              process. Defaults to user specified in image metadata
-                              if unspecified. May also be set in PodSecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext, the
-                              value specified in SecurityContext takes precedence.
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
-                            description:
-                              The SELinux context to be applied to the container.
-                              If unspecified, the container runtime will allocate a
-                              random SELinux context for each container.  May also be
-                              set in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence.
-                            properties:
-                              level:
-                                description:
-                                  Level is SELinux level label that applies
-                                  to the container.
-                                type: string
-                              role:
-                                description:
-                                  Role is a SELinux role label that applies
-                                  to the container.
-                                type: string
-                              type:
-                                description:
-                                  Type is a SELinux type label that applies
-                                  to the container.
-                                type: string
-                              user:
-                                description:
-                                  User is a SELinux user label that applies
-                                  to the container.
-                                type: string
-                            type: object
-                          seccompProfile:
-                            description:
-                              The seccomp options to use by this container.
-                              If seccomp options are provided at both the pod & container
-                              level, the container options override the pod options.
-                            properties:
-                              localhostProfile:
-                                description:
-                                  localhostProfile indicates a profile defined
-                                  in a file on the node should be used. The profile
-                                  must be preconfigured on the node to work. Must be
-                                  a descending path, relative to the kubelet's configured
-                                  seccomp profile location. Must only be set if type
-                                  is "Localhost".
-                                type: string
-                              type:
-                                description:
-                                  "type indicates which kind of seccomp profile
-                                  will be applied. Valid options are: \n Localhost -
-                                  a profile defined in a file on the node should be
-                                  used. RuntimeDefault - the container runtime default
-                                  profile should be used. Unconfined - no profile should
-                                  be applied."
-                                type: string
-                            required:
-                              - type
-                            type: object
-                          windowsOptions:
-                            description:
-                              The Windows specific settings applied to all
-                              containers. If unspecified, the options from the PodSecurityContext
-                              will be used. If set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence.
-                            properties:
-                              gmsaCredentialSpec:
-                                description:
-                                  GMSACredentialSpec is where the GMSA admission
-                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                  inlines the contents of the GMSA credential spec named
-                                  by the GMSACredentialSpecName field.
-                                type: string
-                              gmsaCredentialSpecName:
-                                description:
-                                  GMSACredentialSpecName is the name of the
-                                  GMSA credential spec to use.
-                                type: string
-                              runAsUserName:
-                                description:
-                                  The UserName in Windows to run the entrypoint
-                                  of the container process. Defaults to the user specified
-                                  in image metadata if unspecified. May also be set
-                                  in PodSecurityContext. If set in both SecurityContext
-                                  and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence.
-                                type: string
-                            type: object
-                        type: object
-                      startupProbe:
-                        description:
-                          "StartupProbe indicates that the Pod has successfully
-                          initialized. If specified, no other probes are executed until
-                          this completes successfully. If this probe fails, the Pod
-                          will be restarted, just as if the livenessProbe failed. This
-                          can be used to provide different probe parameters at the beginning
-                          of a Pod's lifecycle, when it might take a long time to load
-                          data or warm a cache, than during steady-state operation.
-                          This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                        properties:
-                          exec:
-                            description:
-                              One and only one of the following should be
-                              specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description:
-                                  Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description:
-                              Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description:
-                                  Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description:
-                                  Custom headers to set in the request. HTTP
-                                  allows repeated headers.
-                                items:
-                                  description:
-                                    HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description:
-                                  Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description:
-                                  Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description:
-                              "Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description:
-                              How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description:
-                              Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description:
-                              "TCPSocket specifies an action involving a
-                              TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook"
-                            properties:
-                              host:
-                                description:
-                                  "Optional: Host name to connect to, defaults
-                                  to the pod IP."
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description:
-                                  Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description:
-                              "Number of seconds after which the probe times
-                              out. Defaults to 1 second. Minimum value is 1. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                            format: int32
-                            type: integer
-                        type: object
-                      stdin:
-                        description:
-                          Whether this container should allocate a buffer
-                          for stdin in the container runtime. If this is not set, reads
-                          from stdin in the container will always result in EOF. Default
-                          is false.
-                        type: boolean
-                      stdinOnce:
-                        description:
-                          Whether the container runtime should close the
-                          stdin channel after it has been opened by a single attach.
-                          When stdin is true the stdin stream will remain open across
-                          multiple attach sessions. If stdinOnce is set to true, stdin
-                          is opened on container start, is empty until the first client
-                          attaches to stdin, and then remains open and accepts data
-                          until the client disconnects, at which time stdin is closed
-                          and remains closed until the container is restarted. If this
-                          flag is false, a container processes that reads from stdin
-                          will never receive an EOF. Default is false
-                        type: boolean
-                      terminationMessagePath:
-                        description:
-                          "Optional: Path at which the file to which the
-                          container's termination message will be written is mounted
-                          into the container's filesystem. Message written is intended
-                          to be brief final status, such as an assertion failure message.
-                          Will be truncated by the node if greater than 4096 bytes.
-                          The total message length across all containers will be limited
-                          to 12kb. Defaults to /dev/termination-log. Cannot be updated."
-                        type: string
-                      terminationMessagePolicy:
-                        description:
-                          Indicate how the termination message should be
-                          populated. File will use the contents of terminationMessagePath
-                          to populate the container status message on both success and
-                          failure. FallbackToLogsOnError will use the last chunk of
-                          container log output if the termination message file is empty
-                          and the container exited with an error. The log output is
-                          limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
-                          to File. Cannot be updated.
-                        type: string
-                      tty:
-                        description:
-                          Whether this container should allocate a TTY for
-                          itself, also requires 'stdin' to be true. Default is false.
-                        type: boolean
-                      volumeDevices:
-                        description:
-                          volumeDevices is the list of block devices to be
-                          used by the container.
-                        items:
-                          description:
-                            volumeDevice describes a mapping of a raw block
-                            device within a container.
-                          properties:
-                            devicePath:
-                              description:
-                                devicePath is the path inside of the container
-                                that the device will be mapped to.
-                              type: string
-                            name:
-                              description:
-                                name must match the name of a persistentVolumeClaim
-                                in the pod
-                              type: string
-                          required:
-                            - devicePath
-                            - name
-                          type: object
-                        type: array
-                      volumeMounts:
-                        description:
-                          Pod volumes to mount into the container's filesystem.
-                          Cannot be updated.
-                        items:
-                          description:
-                            VolumeMount describes a mounting of a Volume
-                            within a container.
-                          properties:
-                            mountPath:
-                              description:
-                                Path within the container at which the volume
-                                should be mounted.  Must not contain ':'.
-                              type: string
-                            mountPropagation:
-                              description:
-                                mountPropagation determines how mounts are
-                                propagated from the host to container and the other
-                                way around. When not set, MountPropagationNone is used.
-                                This field is beta in 1.10.
-                              type: string
-                            name:
-                              description: This must match the Name of a Volume.
-                              type: string
-                            readOnly:
-                              description:
-                                Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
-                              type: boolean
-                            subPath:
-                              description:
-                                Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's root).
-                              type: string
-                            subPathExpr:
-                              description:
-                                Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves similarly
-                                to SubPath but environment variable references $(VAR_NAME)
-                                are expanded using the container's environment. Defaults
-                                to "" (volume's root). SubPathExpr and SubPath are mutually
-                                exclusive.
-                              type: string
-                          required:
-                            - mountPath
-                            - name
-                          type: object
-                        type: array
-                      workingDir:
-                        description:
-                          Container's working directory. If not specified,
-                          the container runtime's default will be used, which might
-                          be configured in the container image. Cannot be updated.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                ldapConfiguration:
-                  description:
-                    LdapConfiguration specifies the configuration if you
-                    want to use LDAP
-                  properties:
-                    enabled:
-                      description:
-                        If set to true, we will enable ldap usage into nifi.properties
-                        configuration.
-                      type: boolean
-                    searchBase:
-                      description: Base DN for searching for users (i.e. CN=Users,DC=example,DC=com).
-                      type: string
-                    searchFilter:
-                      description:
-                        Filter for searching for users against the 'User
-                        Search Base'. (i.e. sAMAccountName={0}). The user specified
-                        name is inserted into '{0}'.
-                      type: string
-                    url:
-                      description:
-                        Space-separated list of URLs of the LDAP servers
-                        (i.e. ldap://<hostname>:<port>).
-                      type: string
-                  type: object
-                listenersConfig:
-                  description:
-                    "TODO : add vault VaultConfig         \tVaultConfig         `json:\"vaultConfig,omitempty\"`
-                    listenerConfig specifies nifi's listener specifig configs"
-                  properties:
-                    clusterDomain:
-                      description:
-                        clusterDomain allow to override the default cluster
-                        domain which is "cluster.local"
-                      type: string
-                    internalListeners:
-                      description:
-                        internalListeners specifies settings required to
-                        access nifi internally
-                      items:
-                        description:
-                          InternalListenerConfig defines the internal listener
-                          config for Nifi
-                        properties:
-                          containerPort:
-                            description: The container port.
-                            format: int32
-                            type: integer
-                          name:
-                            description: An identifier for the port which will be configured.
-                            type: string
-                          type:
-                            description:
-                              (Optional field) Type allow to specify if we
-                              are in a specific nifi listener it's allowing to define
-                              some required information such as Cluster Port, Http Port,
-                              Https Port or S2S port
-                            enum:
-                              - cluster
-                              - http
-                              - https
-                              - s2s
-                              - prometheus
-                            type: string
-                        required:
-                          - containerPort
-                          - name
-                        type: object
-                      type: array
-                    sslSecrets:
-                      description:
-                        sslSecrets contains information about ssl related
-                        kubernetes secrets if one of the listener setting type set to
-                        ssl these fields must be populated to
-                      properties:
-                        clusterScoped:
-                          description:
-                            clusterScoped defines if the Issuer created is
-                            cluster or namespace scoped
-                          type: boolean
-                        create:
-                          description:
-                            create tells the installed cert manager to create
-                            the required certs keys
-                          type: boolean
-                        issuerRef:
-                          description:
-                            "issuerRef allow to use an existing issuer to
-                            act as CA : https://cert-manager.io/docs/concepts/issuer/"
-                          properties:
-                            group:
-                              description: Group of the resource being referred to.
-                              type: string
-                            kind:
-                              description: Kind of the resource being referred to.
-                              type: string
-                            name:
-                              description: Name of the resource being referred to.
-                              type: string
-                          required:
-                            - name
-                          type: object
-                        pkiBackend:
-                          description: "TODO : add vault"
-                          enum:
-                            - cert-manager
-                            - vault
-                          type: string
-                        tlsSecretName:
-                          description:
-                            "tlsSecretName should contain all ssl certs required
-                            by nifi including: caCert, caKey, clientCert, clientKey
-                            serverCert, serverKey, peerCert, peerKey"
-                          type: string
-                      required:
-                        - tlsSecretName
-                      type: object
-                    useExternalDNS:
-                      description:
-                        "useExternalDNS allow to manage externalDNS usage
-                        by limiting the DNS names associated to each nodes and load
-                        balancer : <cluster-name>-node-<node Id>.<cluster-name>.<service
-                        name>.<cluster domain>"
-                      type: boolean
-                  required:
-                    - internalListeners
-                  type: object
-                managedAdminUsers:
-                  description:
-                    managedAdminUsers contains the list of users that will
-                    be added to the managed admin group (with all rights)
-                  items:
-                    properties:
-                      identity:
-                        description:
-                          identity field is use to define the user identity
-                          on NiFi cluster side, it use full when the user's name doesn't
-                          suite with Kubernetes resource name.
-                        type: string
-                      name:
-                        description:
-                          name field is use to name the NifiUser resource,
-                          if not identity is provided it will be used to name the user
-                          on NiFi cluster side.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                managedReaderUsers:
-                  description:
-                    managedReaderUsers contains the list of users that will
-                    be added to the managed reader group (with all view rights)
-                  items:
-                    properties:
-                      identity:
-                        description:
-                          identity field is use to define the user identity
-                          on NiFi cluster side, it use full when the user's name doesn't
-                          suite with Kubernetes resource name.
-                        type: string
-                      name:
-                        description:
-                          name field is use to name the NifiUser resource,
-                          if not identity is provided it will be used to name the user
-                          on NiFi cluster side.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                nifiClusterTaskSpec:
-                  description:
-                    NifiClusterTaskSpec specifies the configuration of the
-                    nifi cluster Tasks
-                  properties:
-                    retryDurationMinutes:
-                      description:
-                        RetryDurationMinutes describes the amount of time
-                        the Operator waits for the task
-                      type: integer
-                  required:
-                    - retryDurationMinutes
-                  type: object
-                nifiURI:
-                  description:
-                    nifiURI used access through a LB uri (used if external
-                    type)
-                  type: string
-                nodeConfigGroups:
-                  additionalProperties:
-                    description: NodeConfig defines the node configuration
-                    properties:
-                      fsGroup:
-                        description:
-                          FSGroup define the id of the group for each volumes
-                          in Nifi image
-                        format: int64
-                        minimum: 1
-                        type: integer
-                      image:
-                        description:
-                          " Docker image used by the operator to create the
-                          node associated  https://hub.docker.com/r/apache/nifi/"
-                        type: string
-                      imagePullPolicy:
-                        description:
-                          imagePullPolicy define the pull policy for NiFi
-                          cluster docker image
-                        type: string
-                      imagePullSecrets:
-                        description:
-                          imagePullSecrets specifies the secret to use when
-                          using private registry https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#localobjectreference-v1-core
-                        items:
-                          description:
-                            LocalObjectReference contains enough information
-                            to let you locate the referenced object inside the same
-                            namespace.
-                          properties:
-                            name:
-                              description:
-                                "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?"
-                              type: string
-                          type: object
-                        type: array
-                      isNode:
-                        description:
-                          Set this to true if the instance is a node in a
-                          cluster. https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#basic-cluster-setup
-                        type: boolean
-                      nifiAnnotations:
-                        additionalProperties:
-                          type: string
-                        description:
-                          Additionnal annotation to attach to the pod associated
-                          https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
-                        type: object
-                      nodeAffinity:
-                        description:
-                          nodeAffinity can be specified, operator populates
-                          this value if new pvc added later to node
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            description:
-                              The scheduler will prefer to schedule pods
-                              to nodes that satisfy the affinity expressions specified
-                              by this field, but it may choose a node that violates
-                              one or more of the expressions. The node that is most
-                              preferred is the one with the greatest sum of weights,
-                              i.e. for each node that meets all of the scheduling requirements
-                              (resource request, requiredDuringScheduling affinity expressions,
-                              etc.), compute a sum by iterating through the elements
-                              of this field and adding "weight" to the sum if the node
-                              matches the corresponding matchExpressions; the node(s)
-                              with the highest sum are the most preferred.
-                            items:
-                              description:
-                                An empty preferred scheduling term matches
-                                all objects with implicit weight 0 (i.e. it's a no-op).
-                                A null preferred scheduling term matches no objects
-                                (i.e. is also a no-op).
-                              properties:
-                                preference:
-                                  description:
-                                    A node selector term, associated with
-                                    the corresponding weight.
-                                  properties:
-                                    matchExpressions:
-                                      description:
-                                        A list of node selector requirements
-                                        by node's labels.
-                                      items:
-                                        description:
-                                          A node selector requirement is
-                                          a selector that contains values, a key, and
-                                          an operator that relates the key and values.
-                                        properties:
-                                          key:
-                                            description:
-                                              The label key that the selector
-                                              applies to.
-                                            type: string
-                                          operator:
-                                            description:
-                                              Represents a key's relationship
-                                              to a set of values. Valid operators are
-                                              In, NotIn, Exists, DoesNotExist. Gt, and
-                                              Lt.
-                                            type: string
-                                          values:
-                                            description:
-                                              An array of string values.
-                                              If the operator is In or NotIn, the values
-                                              array must be non-empty. If the operator
-                                              is Exists or DoesNotExist, the values
-                                              array must be empty. If the operator is
-                                              Gt or Lt, the values array must have a
-                                              single element, which will be interpreted
-                                              as an integer. This array is replaced
-                                              during a strategic merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                          - key
-                                          - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      description:
-                                        A list of node selector requirements
-                                        by node's fields.
-                                      items:
-                                        description:
-                                          A node selector requirement is
-                                          a selector that contains values, a key, and
-                                          an operator that relates the key and values.
-                                        properties:
-                                          key:
-                                            description:
-                                              The label key that the selector
-                                              applies to.
-                                            type: string
-                                          operator:
-                                            description:
-                                              Represents a key's relationship
-                                              to a set of values. Valid operators are
-                                              In, NotIn, Exists, DoesNotExist. Gt, and
-                                              Lt.
-                                            type: string
-                                          values:
-                                            description:
-                                              An array of string values.
-                                              If the operator is In or NotIn, the values
-                                              array must be non-empty. If the operator
-                                              is Exists or DoesNotExist, the values
-                                              array must be empty. If the operator is
-                                              Gt or Lt, the values array must have a
-                                              single element, which will be interpreted
-                                              as an integer. This array is replaced
-                                              during a strategic merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                          - key
-                                          - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                weight:
-                                  description:
-                                    Weight associated with matching the corresponding
-                                    nodeSelectorTerm, in the range 1-100.
-                                  format: int32
-                                  type: integer
-                              required:
-                                - preference
-                                - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            description:
-                              If the affinity requirements specified by this
-                              field are not met at scheduling time, the pod will not
-                              be scheduled onto the node. If the affinity requirements
-                              specified by this field cease to be met at some point
-                              during pod execution (e.g. due to an update), the system
-                              may or may not try to eventually evict the pod from its
-                              node.
-                            properties:
-                              nodeSelectorTerms:
-                                description:
-                                  Required. A list of node selector terms.
-                                  The terms are ORed.
-                                items:
-                                  description:
-                                    A null or empty node selector term matches
-                                    no objects. The requirements of them are ANDed.
-                                    The TopologySelectorTerm type implements a subset
-                                    of the NodeSelectorTerm.
-                                  properties:
-                                    matchExpressions:
-                                      description:
-                                        A list of node selector requirements
-                                        by node's labels.
-                                      items:
-                                        description:
-                                          A node selector requirement is
-                                          a selector that contains values, a key, and
-                                          an operator that relates the key and values.
-                                        properties:
-                                          key:
-                                            description:
-                                              The label key that the selector
-                                              applies to.
-                                            type: string
-                                          operator:
-                                            description:
-                                              Represents a key's relationship
-                                              to a set of values. Valid operators are
-                                              In, NotIn, Exists, DoesNotExist. Gt, and
-                                              Lt.
-                                            type: string
-                                          values:
-                                            description:
-                                              An array of string values.
-                                              If the operator is In or NotIn, the values
-                                              array must be non-empty. If the operator
-                                              is Exists or DoesNotExist, the values
-                                              array must be empty. If the operator is
-                                              Gt or Lt, the values array must have a
-                                              single element, which will be interpreted
-                                              as an integer. This array is replaced
-                                              during a strategic merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                          - key
-                                          - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      description:
-                                        A list of node selector requirements
-                                        by node's fields.
-                                      items:
-                                        description:
-                                          A node selector requirement is
-                                          a selector that contains values, a key, and
-                                          an operator that relates the key and values.
-                                        properties:
-                                          key:
-                                            description:
-                                              The label key that the selector
-                                              applies to.
-                                            type: string
-                                          operator:
-                                            description:
-                                              Represents a key's relationship
-                                              to a set of values. Valid operators are
-                                              In, NotIn, Exists, DoesNotExist. Gt, and
-                                              Lt.
-                                            type: string
-                                          values:
-                                            description:
-                                              An array of string values.
-                                              If the operator is In or NotIn, the values
-                                              array must be non-empty. If the operator
-                                              is Exists or DoesNotExist, the values
-                                              array must be empty. If the operator is
-                                              Gt or Lt, the values array must have a
-                                              single element, which will be interpreted
-                                              as an integer. This array is replaced
-                                              during a strategic merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                          - key
-                                          - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                type: array
-                            required:
-                              - nodeSelectorTerms
-                            type: object
-                        type: object
-                      nodeSelector:
-                        additionalProperties:
-                          type: string
-                        description:
-                          nodeSelector can be specified, which set the pod
-                          to fit on a node https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-                        type: object
-                      provenanceStorage:
-                        description:
-                          provenanceStorage allow to specify the maximum
-                          amount of data provenance information to store at a time https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#write-ahead-provenance-repository-properties
-                        type: string
-                      resourcesRequirements:
-                        description:
-                          resourceRequirements works exactly like Container
-                          resources, the user can specify the limit and the requests
-                          through this property https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description:
-                              "Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description:
-                              "Requests describes the minimum amount of compute
-                              resources required. If Requests is omitted for a container,
-                              it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. More info:
-                              https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
-                            type: object
-                        type: object
-                      runAsUser:
-                        description:
-                          RunAsUser define the id of the user to run in the
-                          Nifi image
-                        format: int64
-                        minimum: 1
-                        type: integer
-                      serviceAccountName:
-                        description:
-                          serviceAccountName specifies the serviceAccount
-                          used for this specific node
-                        type: string
-                      storageConfigs:
-                        description: storageConfigs specifies the node related configs
-                        items:
-                          description: StorageConfig defines the node storage configuration
-                          properties:
-                            mountPath:
-                              description:
-                                Path where the volume will be mount into
-                                the main nifi container inside the pod.
-                              type: string
-                            name:
-                              description:
-                                Name of the storage config, used to name
-                                PV to reuse into sidecars for example.
-                              pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
-                              type: string
-                            pvcSpec:
-                              description: Kubernetes PVC spec
-                              properties:
-                                accessModes:
-                                  description:
-                                    "AccessModes contains the desired access
-                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1"
-                                  items:
-                                    type: string
-                                  type: array
-                                dataSource:
-                                  description:
-                                    "This field can be used to specify either:
-                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim) * An existing
-                                    custom resource that implements data population
-                                    (Alpha) In order to use custom resource types that
-                                    implement data population, the AnyVolumeDataSource
-                                    feature gate must be enabled. If the provisioner
-                                    or an external controller can support the specified
-                                    data source, it will create a new volume based on
-                                    the contents of the specified data source."
-                                  properties:
-                                    apiGroup:
-                                      description:
-                                        APIGroup is the group for the resource
-                                        being referenced. If APIGroup is not specified,
-                                        the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is
-                                        required.
-                                      type: string
-                                    kind:
-                                      description:
-                                        Kind is the type of resource being
-                                        referenced
-                                      type: string
-                                    name:
-                                      description:
-                                        Name is the name of resource being
-                                        referenced
-                                      type: string
-                                  required:
-                                    - kind
-                                    - name
-                                  type: object
-                                resources:
-                                  description:
-                                    "Resources represents the minimum resources
-                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
-                                  properties:
-                                    limits:
-                                      additionalProperties:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      description:
-                                        "Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
-                                      type: object
-                                    requests:
-                                      additionalProperties:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      description:
-                                        "Requests describes the minimum amount
-                                        of compute resources required. If Requests is
-                                        omitted for a container, it defaults to Limits
-                                        if that is explicitly specified, otherwise to
-                                        an implementation-defined value. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
-                                      type: object
-                                  type: object
-                                selector:
-                                  description:
-                                    A label query over volumes to consider
-                                    for binding.
-                                  properties:
-                                    matchExpressions:
-                                      description:
-                                        matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description:
-                                          A label selector requirement is
-                                          a selector that contains values, a key, and
-                                          an operator that relates the key and values.
-                                        properties:
-                                          key:
-                                            description:
-                                              key is the label key that the
-                                              selector applies to.
-                                            type: string
-                                          operator:
-                                            description:
-                                              operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and DoesNotExist.
-                                            type: string
-                                          values:
-                                            description:
-                                              values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If
-                                              the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array
-                                              is replaced during a strategic merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                          - key
-                                          - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description:
-                                        matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is "In",
-                                        and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                storageClassName:
-                                  description:
-                                    "Name of the StorageClass required by
-                                    the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1"
-                                  type: string
-                                volumeMode:
-                                  description:
-                                    volumeMode defines what type of volume
-                                    is required by the claim. Value of Filesystem is
-                                    implied when not included in claim spec.
-                                  type: string
-                                volumeName:
-                                  description:
-                                    VolumeName is the binding reference to
-                                    the PersistentVolume backing this claim.
-                                  type: string
-                              type: object
-                          required:
-                            - mountPath
-                            - name
-                            - pvcSpec
-                          type: object
-                        type: array
-                      tolerations:
-                        description:
-                          tolerations can be specified, which set the pod's
-                          tolerations https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/#concepts
-                        items:
-                          description:
-                            The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
-                          properties:
-                            effect:
-                              description:
-                                Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
-                              type: string
-                            key:
-                              description:
-                                Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
-                              type: string
-                            operator:
-                              description:
-                                Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
-                              type: string
-                            tolerationSeconds:
-                              description:
-                                TolerationSeconds represents the period of
-                                time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
-                              format: int64
-                              type: integer
-                            value:
-                              description:
-                                Value is the taint value the toleration matches
-                                to. If the operator is Exists, the value should be empty,
-                                otherwise just a regular string.
-                              type: string
-                          type: object
-                        type: array
-                    type: object
-                  description:
-                    nodeConfigGroups specifies multiple node configs with
-                    unique name
-                  type: object
-                nodeURITemplate:
-                  description:
-                    nodeURITemplate used to dynamically compute node uri
-                    (used if external type)
-                  type: string
-                nodes:
-                  description:
-                    all node requires an image, unique id, and storageConfigs
-                    settings
-                  items:
-                    description: Node defines the nifi node basic configuration
-                    properties:
-                      id:
-                        description: Unique Node id
-                        format: int32
-                        type: integer
-                      nodeConfig:
-                        description: node configuration
-                        properties:
-                          fsGroup:
-                            description:
-                              FSGroup define the id of the group for each
-                              volumes in Nifi image
-                            format: int64
-                            minimum: 1
-                            type: integer
-                          image:
-                            description:
-                              " Docker image used by the operator to create
-                              the node associated  https://hub.docker.com/r/apache/nifi/"
-                            type: string
-                          imagePullPolicy:
-                            description:
-                              imagePullPolicy define the pull policy for
-                              NiFi cluster docker image
-                            type: string
-                          imagePullSecrets:
-                            description:
-                              imagePullSecrets specifies the secret to use
-                              when using private registry https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#localobjectreference-v1-core
-                            items:
-                              description:
-                                LocalObjectReference contains enough information
-                                to let you locate the referenced object inside the same
-                                namespace.
-                              properties:
-                                name:
-                                  description:
-                                    "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?"
-                                  type: string
-                              type: object
-                            type: array
-                          isNode:
-                            description:
-                              Set this to true if the instance is a node
-                              in a cluster. https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#basic-cluster-setup
-                            type: boolean
-                          nifiAnnotations:
-                            additionalProperties:
-                              type: string
-                            description:
-                              Additionnal annotation to attach to the pod
-                              associated https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
-                            type: object
-                          nodeAffinity:
-                            description:
-                              nodeAffinity can be specified, operator populates
-                              this value if new pvc added later to node
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                description:
-                                  The scheduler will prefer to schedule pods
-                                  to nodes that satisfy the affinity expressions specified
-                                  by this field, but it may choose a node that violates
-                                  one or more of the expressions. The node that is most
-                                  preferred is the one with the greatest sum of weights,
-                                  i.e. for each node that meets all of the scheduling
-                                  requirements (resource request, requiredDuringScheduling
-                                  affinity expressions, etc.), compute a sum by iterating
-                                  through the elements of this field and adding "weight"
-                                  to the sum if the node matches the corresponding matchExpressions;
-                                  the node(s) with the highest sum are the most preferred.
-                                items:
-                                  description:
-                                    An empty preferred scheduling term matches
-                                    all objects with implicit weight 0 (i.e. it's a
-                                    no-op). A null preferred scheduling term matches
-                                    no objects (i.e. is also a no-op).
-                                  properties:
-                                    preference:
-                                      description:
-                                        A node selector term, associated
-                                        with the corresponding weight.
-                                      properties:
-                                        matchExpressions:
-                                          description:
-                                            A list of node selector requirements
-                                            by node's labels.
-                                          items:
-                                            description:
-                                              A node selector requirement
-                                              is a selector that contains values, a
-                                              key, and an operator that relates the
-                                              key and values.
-                                            properties:
-                                              key:
-                                                description:
-                                                  The label key that the
-                                                  selector applies to.
-                                                type: string
-                                              operator:
-                                                description:
-                                                  Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
-                                                type: string
-                                              values:
-                                                description:
-                                                  An array of string values.
-                                                  If the operator is In or NotIn, the
-                                                  values array must be non-empty. If
-                                                  the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If
-                                                  the operator is Gt or Lt, the values
-                                                  array must have a single element,
-                                                  which will be interpreted as an integer.
-                                                  This array is replaced during a strategic
-                                                  merge patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                              - key
-                                              - operator
-                                            type: object
-                                          type: array
-                                        matchFields:
-                                          description:
-                                            A list of node selector requirements
-                                            by node's fields.
-                                          items:
-                                            description:
-                                              A node selector requirement
-                                              is a selector that contains values, a
-                                              key, and an operator that relates the
-                                              key and values.
-                                            properties:
-                                              key:
-                                                description:
-                                                  The label key that the
-                                                  selector applies to.
-                                                type: string
-                                              operator:
-                                                description:
-                                                  Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
-                                                type: string
-                                              values:
-                                                description:
-                                                  An array of string values.
-                                                  If the operator is In or NotIn, the
-                                                  values array must be non-empty. If
-                                                  the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If
-                                                  the operator is Gt or Lt, the values
-                                                  array must have a single element,
-                                                  which will be interpreted as an integer.
-                                                  This array is replaced during a strategic
-                                                  merge patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                              - key
-                                              - operator
-                                            type: object
-                                          type: array
-                                      type: object
-                                    weight:
-                                      description:
-                                        Weight associated with matching the
-                                        corresponding nodeSelectorTerm, in the range
-                                        1-100.
-                                      format: int32
-                                      type: integer
-                                  required:
-                                    - preference
-                                    - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                description:
-                                  If the affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the affinity
-                                  requirements specified by this field cease to be met
-                                  at some point during pod execution (e.g. due to an
-                                  update), the system may or may not try to eventually
-                                  evict the pod from its node.
-                                properties:
-                                  nodeSelectorTerms:
-                                    description:
-                                      Required. A list of node selector terms.
-                                      The terms are ORed.
-                                    items:
-                                      description:
-                                        A null or empty node selector term
-                                        matches no objects. The requirements of them
-                                        are ANDed. The TopologySelectorTerm type implements
-                                        a subset of the NodeSelectorTerm.
-                                      properties:
-                                        matchExpressions:
-                                          description:
-                                            A list of node selector requirements
-                                            by node's labels.
-                                          items:
-                                            description:
-                                              A node selector requirement
-                                              is a selector that contains values, a
-                                              key, and an operator that relates the
-                                              key and values.
-                                            properties:
-                                              key:
-                                                description:
-                                                  The label key that the
-                                                  selector applies to.
-                                                type: string
-                                              operator:
-                                                description:
-                                                  Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
-                                                type: string
-                                              values:
-                                                description:
-                                                  An array of string values.
-                                                  If the operator is In or NotIn, the
-                                                  values array must be non-empty. If
-                                                  the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If
-                                                  the operator is Gt or Lt, the values
-                                                  array must have a single element,
-                                                  which will be interpreted as an integer.
-                                                  This array is replaced during a strategic
-                                                  merge patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                              - key
-                                              - operator
-                                            type: object
-                                          type: array
-                                        matchFields:
-                                          description:
-                                            A list of node selector requirements
-                                            by node's fields.
-                                          items:
-                                            description:
-                                              A node selector requirement
-                                              is a selector that contains values, a
-                                              key, and an operator that relates the
-                                              key and values.
-                                            properties:
-                                              key:
-                                                description:
-                                                  The label key that the
-                                                  selector applies to.
-                                                type: string
-                                              operator:
-                                                description:
-                                                  Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
-                                                type: string
-                                              values:
-                                                description:
-                                                  An array of string values.
-                                                  If the operator is In or NotIn, the
-                                                  values array must be non-empty. If
-                                                  the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. If
-                                                  the operator is Gt or Lt, the values
-                                                  array must have a single element,
-                                                  which will be interpreted as an integer.
-                                                  This array is replaced during a strategic
-                                                  merge patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                              - key
-                                              - operator
-                                            type: object
-                                          type: array
-                                      type: object
-                                    type: array
-                                required:
-                                  - nodeSelectorTerms
-                                type: object
-                            type: object
-                          nodeSelector:
-                            additionalProperties:
-                              type: string
-                            description:
-                              nodeSelector can be specified, which set the
-                              pod to fit on a node https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-                            type: object
-                          provenanceStorage:
-                            description:
-                              provenanceStorage allow to specify the maximum
-                              amount of data provenance information to store at a time
-                              https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#write-ahead-provenance-repository-properties
-                            type: string
-                          resourcesRequirements:
-                            description:
-                              resourceRequirements works exactly like Container
-                              resources, the user can specify the limit and the requests
-                              through this property https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
-                            properties:
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description:
-                                  "Limits describes the maximum amount of
-                                  compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description:
-                                  "Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
-                                type: object
-                            type: object
-                          runAsUser:
-                            description:
-                              RunAsUser define the id of the user to run
-                              in the Nifi image
-                            format: int64
-                            minimum: 1
-                            type: integer
-                          serviceAccountName:
-                            description:
-                              serviceAccountName specifies the serviceAccount
-                              used for this specific node
-                            type: string
-                          storageConfigs:
-                            description: storageConfigs specifies the node related configs
-                            items:
-                              description: StorageConfig defines the node storage configuration
-                              properties:
-                                mountPath:
-                                  description:
-                                    Path where the volume will be mount into
-                                    the main nifi container inside the pod.
-                                  type: string
-                                name:
-                                  description:
-                                    Name of the storage config, used to name
-                                    PV to reuse into sidecars for example.
-                                  pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
-                                  type: string
-                                pvcSpec:
-                                  description: Kubernetes PVC spec
-                                  properties:
-                                    accessModes:
-                                      description:
-                                        "AccessModes contains the desired
-                                        access modes the volume should have. More info:
-                                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1"
-                                      items:
-                                        type: string
-                                      type: array
-                                    dataSource:
-                                      description:
-                                        "This field can be used to specify
-                                        either: * An existing VolumeSnapshot object
-                                        (snapshot.storage.k8s.io/VolumeSnapshot) * An
-                                        existing PVC (PersistentVolumeClaim) * An existing
-                                        custom resource that implements data population
-                                        (Alpha) In order to use custom resource types
-                                        that implement data population, the AnyVolumeDataSource
-                                        feature gate must be enabled. If the provisioner
-                                        or an external controller can support the specified
-                                        data source, it will create a new volume based
-                                        on the contents of the specified data source."
-                                      properties:
-                                        apiGroup:
-                                          description:
-                                            APIGroup is the group for the
-                                            resource being referenced. If APIGroup is
-                                            not specified, the specified Kind must be
-                                            in the core API group. For any other third-party
-                                            types, APIGroup is required.
-                                          type: string
-                                        kind:
-                                          description:
-                                            Kind is the type of resource
-                                            being referenced
-                                          type: string
-                                        name:
-                                          description:
-                                            Name is the name of resource
-                                            being referenced
-                                          type: string
-                                      required:
-                                        - kind
-                                        - name
-                                      type: object
-                                    resources:
-                                      description:
-                                        "Resources represents the minimum
-                                        resources the volume should have. More info:
-                                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
-                                      properties:
-                                        limits:
-                                          additionalProperties:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          description:
-                                            "Limits describes the maximum
-                                            amount of compute resources allowed. More
-                                            info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
-                                          type: object
-                                        requests:
-                                          additionalProperties:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          description:
-                                            "Requests describes the minimum
-                                            amount of compute resources required. If
-                                            Requests is omitted for a container, it
-                                            defaults to Limits if that is explicitly
-                                            specified, otherwise to an implementation-defined
-                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
-                                          type: object
-                                      type: object
-                                    selector:
-                                      description:
-                                        A label query over volumes to consider
-                                        for binding.
-                                      properties:
-                                        matchExpressions:
-                                          description:
-                                            matchExpressions is a list of
-                                            label selector requirements. The requirements
-                                            are ANDed.
-                                          items:
-                                            description:
-                                              A label selector requirement
-                                              is a selector that contains values, a
-                                              key, and an operator that relates the
-                                              key and values.
-                                            properties:
-                                              key:
-                                                description:
-                                                  key is the label key that
-                                                  the selector applies to.
-                                                type: string
-                                              operator:
-                                                description:
-                                                  operator represents a key's
-                                                  relationship to a set of values. Valid
-                                                  operators are In, NotIn, Exists and
-                                                  DoesNotExist.
-                                                type: string
-                                              values:
-                                                description:
-                                                  values is an array of string
-                                                  values. If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This
-                                                  array is replaced during a strategic
-                                                  merge patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                              - key
-                                              - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          description:
-                                            matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator is
-                                            "In", and the values array contains only
-                                            "value". The requirements are ANDed.
-                                          type: object
-                                      type: object
-                                    storageClassName:
-                                      description:
-                                        "Name of the StorageClass required
-                                        by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1"
-                                      type: string
-                                    volumeMode:
-                                      description:
-                                        volumeMode defines what type of volume
-                                        is required by the claim. Value of Filesystem
-                                        is implied when not included in claim spec.
-                                      type: string
-                                    volumeName:
-                                      description:
-                                        VolumeName is the binding reference
-                                        to the PersistentVolume backing this claim.
-                                      type: string
-                                  type: object
-                              required:
-                                - mountPath
-                                - name
-                                - pvcSpec
-                              type: object
-                            type: array
-                          tolerations:
-                            description:
-                              tolerations can be specified, which set the
-                              pod's tolerations https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/#concepts
-                            items:
-                              description:
-                                The pod this Toleration is attached to tolerates
-                                any taint that matches the triple <key,value,effect>
-                                using the matching operator <operator>.
-                              properties:
-                                effect:
-                                  description:
-                                    Effect indicates the taint effect to
-                                    match. Empty means match all taint effects. When
-                                    specified, allowed values are NoSchedule, PreferNoSchedule
-                                    and NoExecute.
-                                  type: string
-                                key:
-                                  description:
-                                    Key is the taint key that the toleration
-                                    applies to. Empty means match all taint keys. If
-                                    the key is empty, operator must be Exists; this
-                                    combination means to match all values and all keys.
-                                  type: string
-                                operator:
-                                  description:
-                                    Operator represents a key's relationship
-                                    to the value. Valid operators are Exists and Equal.
-                                    Defaults to Equal. Exists is equivalent to wildcard
-                                    for value, so that a pod can tolerate all taints
-                                    of a particular category.
-                                  type: string
-                                tolerationSeconds:
-                                  description:
-                                    TolerationSeconds represents the period
-                                    of time the toleration (which must be of effect
-                                    NoExecute, otherwise this field is ignored) tolerates
-                                    the taint. By default, it is not set, which means
-                                    tolerate the taint forever (do not evict). Zero
-                                    and negative values will be treated as 0 (evict
-                                    immediately) by the system.
-                                  format: int64
-                                  type: integer
-                                value:
-                                  description:
-                                    Value is the taint value the toleration
-                                    matches to. If the operator is Exists, the value
-                                    should be empty, otherwise just a regular string.
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                      nodeConfigGroup:
-                        description:
-                          nodeConfigGroup can be used to ease the node configuration,
-                          if set only the id is required
-                        type: string
-                      readOnlyConfig:
-                        description:
-                          readOnlyConfig can be used to pass Nifi node config
-                          https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html
-                          which has type read-only these config changes will trigger
-                          rolling upgrade
-                        properties:
-                          additionalSharedEnvs:
-                            description:
-                              AdditionalSharedEnvs define a set of additional
-                              env variables that will shared between all init containers
-                              and containers in the pod.
-                            items:
-                              description:
-                                EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description:
-                                    Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description:
-                                    'Variable references $(VAR_NAME) are
-                                    expanded using the previous defined environment
-                                    variables in the container and any service environment
-                                    variables. If a variable cannot be resolved, the
-                                    reference in the input string will be unchanged.
-                                    The $(VAR_NAME) syntax can be escaped with a double
-                                    $$, ie: $$(VAR_NAME). Escaped references will never
-                                    be expanded, regardless of whether the variable
-                                    exists or not. Defaults to "".'
-                                  type: string
-                                valueFrom:
-                                  description:
-                                    Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          description:
-                                            "Name of the referent. More info:
-                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?"
-                                          type: string
-                                        optional:
-                                          description:
-                                            Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                        - key
-                                      type: object
-                                    fieldRef:
-                                      description:
-                                        "Selects a field of the pod: supports
-                                        metadata.name, metadata.namespace, `metadata.labels['<KEY>']`,
-                                        `metadata.annotations['<KEY>']`, spec.nodeName,
-                                        spec.serviceAccountName, status.hostIP, status.podIP,
-                                        status.podIPs."
-                                      properties:
-                                        apiVersion:
-                                          description:
-                                            Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description:
-                                            Path of the field to select in
-                                            the specified API version.
-                                          type: string
-                                      required:
-                                        - fieldPath
-                                      type: object
-                                    resourceFieldRef:
-                                      description:
-                                        "Selects a resource of the container:
-                                        only resources limits and requests (limits.cpu,
-                                        limits.memory, limits.ephemeral-storage, requests.cpu,
-                                        requests.memory and requests.ephemeral-storage)
-                                        are currently supported."
-                                      properties:
-                                        containerName:
-                                          description:
-                                            "Container name: required for
-                                            volumes, optional for env vars"
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          description:
-                                            Specifies the output format of
-                                            the exposed resources, defaults to "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: "Required: resource to select"
-                                          type: string
-                                      required:
-                                        - resource
-                                      type: object
-                                    secretKeyRef:
-                                      description:
-                                        Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description:
-                                            The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description:
-                                            "Name of the referent. More info:
-                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?"
-                                          type: string
-                                        optional:
-                                          description:
-                                            Specify whether the Secret or
-                                            its key must be defined
-                                          type: boolean
-                                      required:
-                                        - key
-                                      type: object
-                                  type: object
-                              required:
-                                - name
-                              type: object
-                            type: array
-                          bootstrapNotificationServicesConfig:
-                            description:
-                              BootstrapNotificationServices configuration
-                              that will be applied to the node.
-                            properties:
-                              replaceConfigMap:
-                                description:
-                                  bootstrap_notifications_services.xml configuration
-                                  that will replace the one produced based on template
-                                properties:
-                                  data:
-                                    description:
-                                      The key of the value,in data content,
-                                      that we want use.
-                                    type: string
-                                  name:
-                                    description:
-                                      Name of the configmap that we want
-                                      to refer.
-                                    type: string
-                                  namespace:
-                                    description:
-                                      Namespace where is located the secret
-                                      that we want to refer.
-                                    type: string
-                                required:
-                                  - data
-                                  - name
-                                type: object
-                              replaceSecretConfig:
-                                description:
-                                  bootstrap_notifications_services.xml configuration
-                                  that will replace the one produced based on template
-                                  and overrideConfigMap
-                                properties:
-                                  data:
-                                    description:
-                                      The key of the value,in data content,
-                                      that we want use.
-                                    type: string
-                                  name:
-                                    description:
-                                      Name of the configmap that we want
-                                      to refer.
-                                    type: string
-                                  namespace:
-                                    description:
-                                      Namespace where is located the secret
-                                      that we want to refer.
-                                    type: string
-                                required:
-                                  - data
-                                  - name
-                                type: object
-                            type: object
-                          bootstrapProperties:
-                            description:
-                              BootstrapProperties configuration that will
-                              be applied to the node.
-                            properties:
-                              nifiJvmMemory:
-                                description: JVM memory settings
-                                type: string
-                              overrideConfigMap:
-                                description:
-                                  Additionnals bootstrap.properties configuration
-                                  that will override the one produced based on template
-                                  and configuration
-                                properties:
-                                  data:
-                                    description:
-                                      The key of the value,in data content,
-                                      that we want use.
-                                    type: string
-                                  name:
-                                    description:
-                                      Name of the configmap that we want
-                                      to refer.
-                                    type: string
-                                  namespace:
-                                    description:
-                                      Namespace where is located the secret
-                                      that we want to refer.
-                                    type: string
-                                required:
-                                  - data
-                                  - name
-                                type: object
-                              overrideConfigs:
-                                description:
-                                  Additionnals bootstrap.properties configuration
-                                  that will override the one produced based on template
-                                  and configurations.
-                                type: string
-                              overrideSecretConfig:
-                                description:
-                                  Additionnals bootstrap.properties configuration
-                                  that will override the one produced based on template,
-                                  configurations, overrideConfigMap and overrideConfigs.
-                                properties:
-                                  data:
-                                    description:
-                                      The key of the value,in data content,
-                                      that we want use.
-                                    type: string
-                                  name:
-                                    description:
-                                      Name of the configmap that we want
-                                      to refer.
-                                    type: string
-                                  namespace:
-                                    description:
-                                      Namespace where is located the secret
-                                      that we want to refer.
-                                    type: string
-                                required:
-                                  - data
-                                  - name
-                                type: object
-                            type: object
-                          logbackConfig:
-                            description:
-                              Logback configuration that will be applied
-                              to the node.
-                            properties:
-                              replaceConfigMap:
-                                description:
-                                  logback.xml configuration that will replace
-                                  the one produced based on template
-                                properties:
-                                  data:
-                                    description:
-                                      The key of the value,in data content,
-                                      that we want use.
-                                    type: string
-                                  name:
-                                    description:
-                                      Name of the configmap that we want
-                                      to refer.
-                                    type: string
-                                  namespace:
-                                    description:
-                                      Namespace where is located the secret
-                                      that we want to refer.
-                                    type: string
-                                required:
-                                  - data
-                                  - name
-                                type: object
-                              replaceSecretConfig:
-                                description:
-                                  logback.xml configuration that will replace
-                                  the one produced based on template and overrideConfigMap
-                                properties:
-                                  data:
-                                    description:
-                                      The key of the value,in data content,
-                                      that we want use.
-                                    type: string
-                                  name:
-                                    description:
-                                      Name of the configmap that we want
-                                      to refer.
-                                    type: string
-                                  namespace:
-                                    description:
-                                      Namespace where is located the secret
-                                      that we want to refer.
-                                    type: string
-                                required:
-                                  - data
-                                  - name
-                                type: object
-                            type: object
-                          maximumTimerDrivenThreadCount:
-                            description:
-                              MaximumTimerDrivenThreadCount define the maximum
-                              number of threads for timer driven processors available
-                              to the system.
-                            format: int32
-                            type: integer
-                          nifiProperties:
-                            description:
-                              NifiProperties configuration that will be applied
-                              to the node.
-                            properties:
-                              authorizer:
-                                description:
-                                  Indicates which of the configured authorizers
-                                  in the authorizers.xml file to use https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#authorizer-configuration
-                                type: string
-                              needClientAuth:
-                                description: Nifi security client auth
-                                type: boolean
-                              overrideConfigMap:
-                                description:
-                                  Additionnals nifi.properties configuration
-                                  that will override the one produced based on template
-                                  and configuration
-                                properties:
-                                  data:
-                                    description:
-                                      The key of the value,in data content,
-                                      that we want use.
-                                    type: string
-                                  name:
-                                    description:
-                                      Name of the configmap that we want
-                                      to refer.
-                                    type: string
-                                  namespace:
-                                    description:
-                                      Namespace where is located the secret
-                                      that we want to refer.
-                                    type: string
-                                required:
-                                  - data
-                                  - name
-                                type: object
-                              overrideConfigs:
-                                description:
-                                  Additionnals nifi.properties configuration
-                                  that will override the one produced based on template,
-                                  configurations and overrideConfigMap.
-                                type: string
-                              overrideSecretConfig:
-                                description:
-                                  Additionnals nifi.properties configuration
-                                  that will override the one produced based on template,
-                                  configurations, overrideConfigMap and overrideConfigs.
-                                properties:
-                                  data:
-                                    description:
-                                      The key of the value,in data content,
-                                      that we want use.
-                                    type: string
-                                  name:
-                                    description:
-                                      Name of the configmap that we want
-                                      to refer.
-                                    type: string
-                                  namespace:
-                                    description:
-                                      Namespace where is located the secret
-                                      that we want to refer.
-                                    type: string
-                                required:
-                                  - data
-                                  - name
-                                type: object
-                              webProxyHosts:
-                                description:
-                                  A comma separated list of allowed HTTP
-                                  Host header values to consider when NiFi is running
-                                  securely and will be receiving requests to a different
-                                  host[:port] than it is bound to. https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#web-properties
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          zookeeperProperties:
-                            description:
-                              ZookeeperProperties configuration that will
-                              be applied to the node.
-                            properties:
-                              overrideConfigMap:
-                                description:
-                                  Additionnals zookeeper.properties configuration
-                                  that will override the one produced based on template
-                                  and configuration
-                                properties:
-                                  data:
-                                    description:
-                                      The key of the value,in data content,
-                                      that we want use.
-                                    type: string
-                                  name:
-                                    description:
-                                      Name of the configmap that we want
-                                      to refer.
-                                    type: string
-                                  namespace:
-                                    description:
-                                      Namespace where is located the secret
-                                      that we want to refer.
-                                    type: string
-                                required:
-                                  - data
-                                  - name
-                                type: object
-                              overrideConfigs:
-                                description:
-                                  Additionnals zookeeper.properties configuration
-                                  that will override the one produced based on template
-                                  and configurations.
-                                type: string
-                              overrideSecretConfig:
-                                description:
-                                  Additionnals zookeeper.properties configuration
-                                  that will override the one produced based on template,
-                                  configurations, overrideConfigMap and overrideConfigs.
-                                properties:
-                                  data:
-                                    description:
-                                      The key of the value,in data content,
-                                      that we want use.
-                                    type: string
-                                  name:
-                                    description:
-                                      Name of the configmap that we want
-                                      to refer.
-                                    type: string
-                                  namespace:
-                                    description:
-                                      Namespace where is located the secret
-                                      that we want to refer.
-                                    type: string
-                                required:
-                                  - data
-                                  - name
-                                type: object
-                            type: object
-                        type: object
-                    required:
-                      - id
-                    type: object
-                  type: array
-                oneNifiNodePerNode:
-                  description:
-                    oneNifiNodePerNode if set to true every nifi node is
-                    started on a new node, if there is not enough node to do that it
-                    will stay in pending state. If set to false the operator also tries
-                    to schedule the nifi node to a unique node but if the node number
-                    is insufficient the nifi node will be scheduled to a node where
-                    a nifi node is already running.
-                  type: boolean
-                pod:
-                  description: Pod defines the policy for  pods owned by NiFiKop operator.
-                  properties:
-                    annotations:
+                    serviceAnnotations:
                       additionalProperties:
                         type: string
-                      description:
-                        Annotations specifies the annotations to attach to
-                        pods the operator creates
+                      description: 'Annotations is an unstructured key value map stored
+                        with a resource that may be set by external tools to store
+                        and retrieve arbitrary metadata. They are not queryable and
+                        should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
                       type: object
+                    spec:
+                      description: Spec defines the behavior of a service.
+                      properties:
+                        clusterIP:
+                          description: 'clusterIP is the IP address of the service
+                            and is usually assigned randomly by the master. If an
+                            address is specified manually and is not in use by others,
+                            it will be allocated to the service; otherwise, creation
+                            of the service will fail. This field can not be changed
+                            through updates. Valid values are "None", empty string
+                            (""), or a valid IP address. "None" can be specified for
+                            headless services when proxying is not required. Only
+                            applies to types ClusterIP, NodePort, and LoadBalancer.
+                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        externalIPs:
+                          description: externalIPs is a list of IP addresses for which
+                            nodes in the cluster will also accept traffic for this
+                            service.  These IPs are not managed by Kubernetes.  The
+                            user is responsible for ensuring that traffic arrives
+                            at a node with this IP.  A common example is external
+                            load-balancers that are not part of the Kubernetes system.
+                          items:
+                            type: string
+                          type: array
+                        externalName:
+                          description: externalName is the external reference that
+                            kubedns or equivalent will return as a CNAME record for
+                            this service. No proxying will be involved. Must be a
+                            valid RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                            and requires Type to be ExternalName.
+                          type: string
+                        loadBalancerIP:
+                          description: 'Only applies to Service Type: LoadBalancer
+                            LoadBalancer will get created with the IP specified in
+                            this field. This feature depends on whether the underlying
+                            cloud-provider supports specifying the loadBalancerIP
+                            when a load balancer is created. This field will be ignored
+                            if the cloud-provider does not support the feature.'
+                          type: string
+                        loadBalancerSourceRanges:
+                          description: 'If specified and supported by the platform,
+                            this will restrict traffic through the cloud-provider
+                            load-balancer will be restricted to the specified client
+                            IPs. This field will be ignored if the cloud-provider
+                            does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                          items:
+                            type: string
+                          type: array
+                        portConfigs:
+                          description: Contains the list port for the service and
+                            the associated listener
+                          items:
+                            properties:
+                              internalListenerName:
+                                description: The name of the listener which will be
+                                  used as target container.
+                                type: string
+                              port:
+                                description: The port that will be exposed by this
+                                  service.
+                                format: int32
+                                type: integer
+                            required:
+                            - internalListenerName
+                            - port
+                            type: object
+                          type: array
+                        type:
+                          description: 'type determines how the Service is exposed.
+                            Defaults to ClusterIP. Valid options are ExternalName,
+                            ClusterIP, NodePort, and LoadBalancer. "ExternalName"
+                            maps to the specified externalName. "ClusterIP" allocates
+                            a cluster-internal IP address for load-balancing to endpoints.
+                            Endpoints are determined by the selector or if that is
+                            not specified, by manual construction of an Endpoints
+                            object. If clusterIP is "None", no virtual IP is allocated
+                            and the endpoints are published as a set of endpoints
+                            rather than a stable IP. "NodePort" builds on ClusterIP
+                            and allocates a port on every node which routes to the
+                            clusterIP. "LoadBalancer" builds on NodePort and creates
+                            an external load-balancer (if supported in the current
+                            cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                          type: string
+                      required:
+                      - portConfigs
+                      type: object
+                  required:
+                  - spec
                   type: object
-                propagateLabels:
-                  description: propage
-                  type: boolean
-                proxyUrl:
-                  description:
-                    proxyUrl defines the proxy required to query the NiFi
-                    cluster (used if external type)
-                  type: string
-                readOnlyConfig:
-                  description:
-                    readOnlyConfig specifies the read-only type Nifi config
-                    cluster wide, all theses will be merged with node specified readOnly
-                    configurations, so it can be overwritten per node.
+                type: array
+              initContainerImage:
+                description: initContainerImage can override the default image used
+                  into the init container to check if ZoooKeeper server is reachable.
+                type: string
+              initContainers:
+                description: initContainers defines additional initContainers configurations
+                items:
+                  description: A single application container that you want to run
+                    within a pod.
                   properties:
-                    additionalSharedEnvs:
-                      description:
-                        AdditionalSharedEnvs define a set of additional env
-                        variables that will shared between all init containers and containers
-                        in the pod.
+                    args:
+                      description: 'Arguments to the entrypoint. The docker image''s
+                        CMD is used if this is not provided. Variable references $(VAR_NAME)
+                        are expanded using the container''s environment. If a variable
+                        cannot be resolved, the reference in the input string will
+                        be unchanged. The $(VAR_NAME) syntax can be escaped with a
+                        double $$, ie: $$(VAR_NAME). Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                       items:
-                        description:
-                          EnvVar represents an environment variable present
+                        type: string
+                      type: array
+                    command:
+                      description: 'Entrypoint array. Not executed within a shell.
+                        The docker image''s ENTRYPOINT is used if this is not provided.
+                        Variable references $(VAR_NAME) are expanded using the container''s
+                        environment. If a variable cannot be resolved, the reference
+                        in the input string will be unchanged. The $(VAR_NAME) syntax
+                        can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                        references will never be expanded, regardless of whether the
+                        variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                      items:
+                        type: string
+                      type: array
+                    env:
+                      description: List of environment variables to set in the container.
+                        Cannot be updated.
+                      items:
+                        description: EnvVar represents an environment variable present
                           in a Container.
                         properties:
                           name:
-                            description:
-                              Name of the environment variable. Must be a
-                              C_IDENTIFIER.
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
                             type: string
                           value:
-                            description:
-                              'Variable references $(VAR_NAME) are expanded
-                              using the previous defined environment variables in the
-                              container and any service environment variables. If a
-                              variable cannot be resolved, the reference in the input
-                              string will be unchanged. The $(VAR_NAME) syntax can be
-                              escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                              will never be expanded, regardless of whether the variable
-                              exists or not. Defaults to "".'
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previous defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. The $(VAR_NAME) syntax
+                              can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                              references will never be expanded, regardless of whether
+                              the variable exists or not. Defaults to "".'
                             type: string
                           valueFrom:
-                            description:
-                              Source for the environment variable's value.
+                            description: Source for the environment variable's value.
                               Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
@@ -3318,1793 +237,4243 @@ spec:
                                     description: The key to select.
                                     type: string
                                   name:
-                                    description:
-                                      "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       TODO: Add other useful fields. apiVersion, kind,
-                                      uid?"
+                                      uid?'
                                     type: string
                                   optional:
-                                    description:
-                                      Specify whether the ConfigMap or its
-                                      key must be defined
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
                                     type: boolean
                                 required:
-                                  - key
+                                - key
                                 type: object
                               fieldRef:
-                                description:
-                                  "Selects a field of the pod: supports metadata.name,
-                                  metadata.namespace, `metadata.labels['<KEY>']`,
-                                  `metadata.annotations['<KEY>']`, spec.nodeName,
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                   spec.serviceAccountName, status.hostIP, status.podIP,
-                                  status.podIPs."
+                                  status.podIPs.'
                                 properties:
                                   apiVersion:
-                                    description:
-                                      Version of the schema the FieldPath
+                                    description: Version of the schema the FieldPath
                                       is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description:
-                                      Path of the field to select in the
+                                    description: Path of the field to select in the
                                       specified API version.
                                     type: string
                                 required:
-                                  - fieldPath
+                                - fieldPath
                                 type: object
                               resourceFieldRef:
-                                description:
-                                  "Selects a resource of the container: only
-                                  resources limits and requests (limits.cpu, limits.memory,
-                                  limits.ephemeral-storage, requests.cpu, requests.memory
-                                  and requests.ephemeral-storage) are currently supported."
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
                                 properties:
                                   containerName:
-                                    description:
-                                      "Container name: required for volumes,
-                                      optional for env vars"
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description:
-                                      Specifies the output format of the
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
                                       exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: "Required: resource to select"
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
-                                  - resource
+                                - resource
                                 type: object
                               secretKeyRef:
-                                description:
-                                  Selects a key of a secret in the pod's
+                                description: Selects a key of a secret in the pod's
                                   namespace
                                 properties:
                                   key:
-                                    description:
-                                      The key of the secret to select from.  Must
+                                    description: The key of the secret to select from.  Must
                                       be a valid secret key.
                                     type: string
                                   name:
-                                    description:
-                                      "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       TODO: Add other useful fields. apiVersion, kind,
-                                      uid?"
+                                      uid?'
                                     type: string
                                   optional:
-                                    description:
-                                      Specify whether the Secret or its key
-                                      must be defined
+                                    description: Specify whether the Secret or its
+                                      key must be defined
                                     type: boolean
                                 required:
-                                  - key
+                                - key
                                 type: object
                             type: object
                         required:
-                          - name
+                        - name
                         type: object
                       type: array
-                    bootstrapNotificationServicesConfig:
-                      description:
-                        BootstrapNotificationServices configuration that
-                        will be applied to the node.
-                      properties:
-                        replaceConfigMap:
-                          description:
-                            bootstrap_notifications_services.xml configuration
-                            that will replace the one produced based on template
-                          properties:
-                            data:
-                              description:
-                                The key of the value,in data content, that
-                                we want use.
-                              type: string
-                            name:
-                              description: Name of the configmap that we want to refer.
-                              type: string
-                            namespace:
-                              description:
-                                Namespace where is located the secret that
-                                we want to refer.
-                              type: string
-                          required:
-                            - data
-                            - name
-                          type: object
-                        replaceSecretConfig:
-                          description:
-                            bootstrap_notifications_services.xml configuration
-                            that will replace the one produced based on template and
-                            overrideConfigMap
-                          properties:
-                            data:
-                              description:
-                                The key of the value,in data content, that
-                                we want use.
-                              type: string
-                            name:
-                              description: Name of the configmap that we want to refer.
-                              type: string
-                            namespace:
-                              description:
-                                Namespace where is located the secret that
-                                we want to refer.
-                              type: string
-                          required:
-                            - data
-                            - name
-                          type: object
-                      type: object
-                    bootstrapProperties:
-                      description:
-                        BootstrapProperties configuration that will be applied
-                        to the node.
-                      properties:
-                        nifiJvmMemory:
-                          description: JVM memory settings
-                          type: string
-                        overrideConfigMap:
-                          description:
-                            Additionnals bootstrap.properties configuration
-                            that will override the one produced based on template and
-                            configuration
-                          properties:
-                            data:
-                              description:
-                                The key of the value,in data content, that
-                                we want use.
-                              type: string
-                            name:
-                              description: Name of the configmap that we want to refer.
-                              type: string
-                            namespace:
-                              description:
-                                Namespace where is located the secret that
-                                we want to refer.
-                              type: string
-                          required:
-                            - data
-                            - name
-                          type: object
-                        overrideConfigs:
-                          description:
-                            Additionnals bootstrap.properties configuration
-                            that will override the one produced based on template and
-                            configurations.
-                          type: string
-                        overrideSecretConfig:
-                          description:
-                            Additionnals bootstrap.properties configuration
-                            that will override the one produced based on template, configurations,
-                            overrideConfigMap and overrideConfigs.
-                          properties:
-                            data:
-                              description:
-                                The key of the value,in data content, that
-                                we want use.
-                              type: string
-                            name:
-                              description: Name of the configmap that we want to refer.
-                              type: string
-                            namespace:
-                              description:
-                                Namespace where is located the secret that
-                                we want to refer.
-                              type: string
-                          required:
-                            - data
-                            - name
-                          type: object
-                      type: object
-                    logbackConfig:
-                      description:
-                        Logback configuration that will be applied to the
-                        node.
-                      properties:
-                        replaceConfigMap:
-                          description:
-                            logback.xml configuration that will replace the
-                            one produced based on template
-                          properties:
-                            data:
-                              description:
-                                The key of the value,in data content, that
-                                we want use.
-                              type: string
-                            name:
-                              description: Name of the configmap that we want to refer.
-                              type: string
-                            namespace:
-                              description:
-                                Namespace where is located the secret that
-                                we want to refer.
-                              type: string
-                          required:
-                            - data
-                            - name
-                          type: object
-                        replaceSecretConfig:
-                          description:
-                            logback.xml configuration that will replace the
-                            one produced based on template and overrideConfigMap
-                          properties:
-                            data:
-                              description:
-                                The key of the value,in data content, that
-                                we want use.
-                              type: string
-                            name:
-                              description: Name of the configmap that we want to refer.
-                              type: string
-                            namespace:
-                              description:
-                                Namespace where is located the secret that
-                                we want to refer.
-                              type: string
-                          required:
-                            - data
-                            - name
-                          type: object
-                      type: object
-                    maximumTimerDrivenThreadCount:
-                      description:
-                        MaximumTimerDrivenThreadCount define the maximum
-                        number of threads for timer driven processors available to the
-                        system.
-                      format: int32
-                      type: integer
-                    nifiProperties:
-                      description:
-                        NifiProperties configuration that will be applied
-                        to the node.
-                      properties:
-                        authorizer:
-                          description:
-                            Indicates which of the configured authorizers
-                            in the authorizers.xml file to use https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#authorizer-configuration
-                          type: string
-                        needClientAuth:
-                          description: Nifi security client auth
-                          type: boolean
-                        overrideConfigMap:
-                          description:
-                            Additionnals nifi.properties configuration that
-                            will override the one produced based on template and configuration
-                          properties:
-                            data:
-                              description:
-                                The key of the value,in data content, that
-                                we want use.
-                              type: string
-                            name:
-                              description: Name of the configmap that we want to refer.
-                              type: string
-                            namespace:
-                              description:
-                                Namespace where is located the secret that
-                                we want to refer.
-                              type: string
-                          required:
-                            - data
-                            - name
-                          type: object
-                        overrideConfigs:
-                          description:
-                            Additionnals nifi.properties configuration that
-                            will override the one produced based on template, configurations
-                            and overrideConfigMap.
-                          type: string
-                        overrideSecretConfig:
-                          description:
-                            Additionnals nifi.properties configuration that
-                            will override the one produced based on template, configurations,
-                            overrideConfigMap and overrideConfigs.
-                          properties:
-                            data:
-                              description:
-                                The key of the value,in data content, that
-                                we want use.
-                              type: string
-                            name:
-                              description: Name of the configmap that we want to refer.
-                              type: string
-                            namespace:
-                              description:
-                                Namespace where is located the secret that
-                                we want to refer.
-                              type: string
-                          required:
-                            - data
-                            - name
-                          type: object
-                        webProxyHosts:
-                          description:
-                            A comma separated list of allowed HTTP Host header
-                            values to consider when NiFi is running securely and will
-                            be receiving requests to a different host[:port] than it
-                            is bound to. https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#web-properties
-                          items:
+                    envFrom:
+                      description: List of sources to populate environment variables
+                        in the container. The keys defined within a source must be
+                        a C_IDENTIFIER. All invalid keys will be reported as an event
+                        when the container is starting. When a key exists in multiple
+                        sources, the value associated with the last source will take
+                        precedence. Values defined by an Env with a duplicate key
+                        will take precedence. Cannot be updated.
+                      items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
+                                type: boolean
+                            type: object
+                          prefix:
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
                             type: string
-                          type: array
-                      type: object
-                    zookeeperProperties:
-                      description:
-                        ZookeeperProperties configuration that will be applied
-                        to the node.
+                          secretRef:
+                            description: The Secret to select from
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                            type: object
+                        type: object
+                      type: array
+                    image:
+                      description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                        This field is optional to allow higher level config management
+                        to default or override container images in workload controllers
+                        like Deployments and StatefulSets.'
+                      type: string
+                    imagePullPolicy:
+                      description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                        Defaults to Always if :latest tag is specified, or IfNotPresent
+                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                      type: string
+                    lifecycle:
+                      description: Actions that the management system should take
+                        in response to container lifecycle events. Cannot be updated.
                       properties:
-                        overrideConfigMap:
-                          description:
-                            Additionnals zookeeper.properties configuration
-                            that will override the one produced based on template and
-                            configuration
+                        postStart:
+                          description: 'PostStart is called immediately after a container
+                            is created. If the handler fails, the container is terminated
+                            and restarted according to its restart policy. Other management
+                            of the container blocks until the hook completes. More
+                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                           properties:
-                            data:
-                              description:
-                                The key of the value,in data content, that
-                                we want use.
-                              type: string
-                            name:
-                              description: Name of the configmap that we want to refer.
-                              type: string
-                            namespace:
-                              description:
-                                Namespace where is located the secret that
-                                we want to refer.
-                              type: string
-                          required:
-                            - data
-                            - name
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
                           type: object
-                        overrideConfigs:
-                          description:
-                            Additionnals zookeeper.properties configuration
-                            that will override the one produced based on template and
-                            configurations.
-                          type: string
-                        overrideSecretConfig:
-                          description:
-                            Additionnals zookeeper.properties configuration
-                            that will override the one produced based on template, configurations,
-                            overrideConfigMap and overrideConfigs.
+                        preStop:
+                          description: 'PreStop is called immediately before a container
+                            is terminated due to an API request or management event
+                            such as liveness/startup probe failure, preemption, resource
+                            contention, etc. The handler is not called if the container
+                            crashes or exits. The reason for termination is passed
+                            to the handler. The Pod''s termination grace period countdown
+                            begins before the PreStop hooked is executed. Regardless
+                            of the outcome of the handler, the container will eventually
+                            terminate within the Pod''s termination grace period.
+                            Other management of the container blocks until the hook
+                            completes or until the termination grace period is reached.
+                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                           properties:
-                            data:
-                              description:
-                                The key of the value,in data content, that
-                                we want use.
-                              type: string
-                            name:
-                              description: Name of the configmap that we want to refer.
-                              type: string
-                            namespace:
-                              description:
-                                Namespace where is located the secret that
-                                we want to refer.
-                              type: string
-                          required:
-                            - data
-                            - name
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
                           type: object
                       type: object
-                  type: object
-                rootProcessGroupId:
-                  description:
-                    rootProcessGroupId contains the uuid of the root process
-                    group for this cluster (used if external type)
-                  type: string
-                secretRef:
-                  description:
-                    secretRef reference the secret containing the informations
-                    required to authentiticate to the cluster (used if external type)
-                  properties:
+                    livenessProbe:
+                      description: 'Periodic probe of container liveness. Container
+                        will be restarted if the probe fails. Cannot be updated. More
+                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
                     name:
+                      description: Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
                       type: string
-                    namespace:
-                      type: string
-                  required:
-                    - name
-                  type: object
-                service:
-                  description:
-                    Service defines the policy for services owned by NiFiKop
-                    operator.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description:
-                        Annotations specifies the annotations to attach to
-                        services the operator creates
-                      type: object
-                    headlessEnabled:
-                      description:
-                        HeadlessEnabled specifies if the cluster should use
-                        headlessService for Nifi or individual services using service
-                        per nodes may come an handy case of service mesh.
-                      type: boolean
-                  required:
-                    - headlessEnabled
-                  type: object
-                sidecarConfigs:
-                  description: SidecarsConfig defines additional sidecar configurations
-                  items:
-                    description:
-                      A single application container that you want to run
-                      within a pod.
-                    properties:
-                      args:
-                        description:
-                          "Arguments to the entrypoint. The docker image's
-                          CMD is used if this is not provided. Variable references $(VAR_NAME)
-                          are expanded using the container's environment. If a variable
-                          cannot be resolved, the reference in the input string will
-                          be unchanged. The $(VAR_NAME) syntax can be escaped with a
-                          double $$, ie: $$(VAR_NAME). Escaped references will never
-                          be expanded, regardless of whether the variable exists or
-                          not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell"
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        description:
-                          "Entrypoint array. Not executed within a shell.
-                          The docker image's ENTRYPOINT is used if this is not provided.
-                          Variable references $(VAR_NAME) are expanded using the container's
-                          environment. If a variable cannot be resolved, the reference
-                          in the input string will be unchanged. The $(VAR_NAME) syntax
-                          can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
-                          references will never be expanded, regardless of whether the
-                          variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell"
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        description:
-                          List of environment variables to set in the container.
-                          Cannot be updated.
-                        items:
-                          description:
-                            EnvVar represents an environment variable present
-                            in a Container.
-                          properties:
-                            name:
-                              description:
-                                Name of the environment variable. Must be
-                                a C_IDENTIFIER.
-                              type: string
-                            value:
-                              description:
-                                'Variable references $(VAR_NAME) are expanded
-                                using the previous defined environment variables in
-                                the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in the
-                                input string will be unchanged. The $(VAR_NAME) syntax
-                                can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
-                                references will never be expanded, regardless of whether
-                                the variable exists or not. Defaults to "".'
-                              type: string
-                            valueFrom:
-                              description:
-                                Source for the environment variable's value.
-                                Cannot be used if value is not empty.
-                              properties:
-                                configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
-                                  properties:
-                                    key:
-                                      description: The key to select.
-                                      type: string
-                                    name:
-                                      description:
-                                        "Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind,
-                                        uid?"
-                                      type: string
-                                    optional:
-                                      description:
-                                        Specify whether the ConfigMap or
-                                        its key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                                fieldRef:
-                                  description:
-                                    "Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels['<KEY>']`,
-                                    `metadata.annotations['<KEY>']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs."
-                                  properties:
-                                    apiVersion:
-                                      description:
-                                        Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
-                                      type: string
-                                    fieldPath:
-                                      description:
-                                        Path of the field to select in the
-                                        specified API version.
-                                      type: string
-                                  required:
-                                    - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  description:
-                                    "Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported."
-                                  properties:
-                                    containerName:
-                                      description:
-                                        "Container name: required for volumes,
-                                        optional for env vars"
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      description:
-                                        Specifies the output format of the
-                                        exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      description: "Required: resource to select"
-                                      type: string
-                                  required:
-                                    - resource
-                                  type: object
-                                secretKeyRef:
-                                  description:
-                                    Selects a key of a secret in the pod's
-                                    namespace
-                                  properties:
-                                    key:
-                                      description:
-                                        The key of the secret to select from.  Must
-                                        be a valid secret key.
-                                      type: string
-                                    name:
-                                      description:
-                                        "Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind,
-                                        uid?"
-                                      type: string
-                                    optional:
-                                      description:
-                                        Specify whether the Secret or its
-                                        key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                              type: object
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      envFrom:
-                        description:
-                          List of sources to populate environment variables
-                          in the container. The keys defined within a source must be
-                          a C_IDENTIFIER. All invalid keys will be reported as an event
-                          when the container is starting. When a key exists in multiple
-                          sources, the value associated with the last source will take
-                          precedence. Values defined by an Env with a duplicate key
-                          will take precedence. Cannot be updated.
-                        items:
-                          description:
-                            EnvFromSource represents the source of a set
-                            of ConfigMaps
-                          properties:
-                            configMapRef:
-                              description: The ConfigMap to select from
-                              properties:
-                                name:
-                                  description:
-                                    "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?"
-                                  type: string
-                                optional:
-                                  description:
-                                    Specify whether the ConfigMap must be
-                                    defined
-                                  type: boolean
-                              type: object
-                            prefix:
-                              description:
-                                An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
-                              type: string
-                            secretRef:
-                              description: The Secret to select from
-                              properties:
-                                name:
-                                  description:
-                                    "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?"
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret must be defined
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        description:
-                          "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                          This field is optional to allow higher level config management
-                          to default or override container images in workload controllers
-                          like Deployments and StatefulSets."
-                        type: string
-                      imagePullPolicy:
-                        description:
-                          "Image pull policy. One of Always, Never, IfNotPresent.
-                          Defaults to Always if :latest tag is specified, or IfNotPresent
-                          otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images"
-                        type: string
-                      lifecycle:
-                        description:
-                          Actions that the management system should take
-                          in response to container lifecycle events. Cannot be updated.
+                    ports:
+                      description: List of ports to expose from the container. Exposing
+                        a port here gives the system additional information about
+                        the network connections a container uses, but is primarily
+                        informational. Not specifying a port here DOES NOT prevent
+                        that port from being exposed. Any port which is listening
+                        on the default "0.0.0.0" address inside a container will be
+                        accessible from the network. Cannot be updated.
+                      items:
+                        description: ContainerPort represents a network port in a
+                          single container.
                         properties:
-                          postStart:
-                            description:
-                              "PostStart is called immediately after a container
-                              is created. If the handler fails, the container is terminated
-                              and restarted according to its restart policy. Other management
-                              of the container blocks until the hook completes. More
-                              info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks"
-                            properties:
-                              exec:
-                                description:
-                                  One and only one of the following should
-                                  be specified. Exec specifies the action to take.
-                                properties:
-                                  command:
-                                    description:
-                                      Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                description: HTTPGet specifies the http request to perform.
-                                properties:
-                                  host:
-                                    description:
-                                      Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
-                                    type: string
-                                  httpHeaders:
-                                    description:
-                                      Custom headers to set in the request.
-                                      HTTP allows repeated headers.
-                                    items:
-                                      description:
-                                        HTTPHeader describes a custom header
-                                        to be used in HTTP probes
-                                      properties:
-                                        name:
-                                          description: The header field name
-                                          type: string
-                                        value:
-                                          description: The header field value
-                                          type: string
-                                      required:
-                                        - name
-                                        - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    description: Path to access on the HTTP server.
-                                    type: string
-                                  port:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description:
-                                      Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    description:
-                                      Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
-                                    type: string
-                                required:
-                                  - port
-                                type: object
-                              tcpSocket:
-                                description:
-                                  "TCPSocket specifies an action involving
-                                  a TCP port. TCP hooks not yet supported TODO: implement
-                                  a realistic TCP lifecycle hook"
-                                properties:
-                                  host:
-                                    description:
-                                      "Optional: Host name to connect to,
-                                      defaults to the pod IP."
-                                    type: string
-                                  port:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description:
-                                      Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                  - port
-                                type: object
-                            type: object
-                          preStop:
-                            description:
-                              "PreStop is called immediately before a container
-                              is terminated due to an API request or management event
-                              such as liveness/startup probe failure, preemption, resource
-                              contention, etc. The handler is not called if the container
-                              crashes or exits. The reason for termination is passed
-                              to the handler. The Pod's termination grace period countdown
-                              begins before the PreStop hooked is executed. Regardless
-                              of the outcome of the handler, the container will eventually
-                              terminate within the Pod's termination grace period.
-                              Other management of the container blocks until the hook
-                              completes or until the termination grace period is reached.
-                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks"
-                            properties:
-                              exec:
-                                description:
-                                  One and only one of the following should
-                                  be specified. Exec specifies the action to take.
-                                properties:
-                                  command:
-                                    description:
-                                      Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                description: HTTPGet specifies the http request to perform.
-                                properties:
-                                  host:
-                                    description:
-                                      Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
-                                    type: string
-                                  httpHeaders:
-                                    description:
-                                      Custom headers to set in the request.
-                                      HTTP allows repeated headers.
-                                    items:
-                                      description:
-                                        HTTPHeader describes a custom header
-                                        to be used in HTTP probes
-                                      properties:
-                                        name:
-                                          description: The header field name
-                                          type: string
-                                        value:
-                                          description: The header field value
-                                          type: string
-                                      required:
-                                        - name
-                                        - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    description: Path to access on the HTTP server.
-                                    type: string
-                                  port:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description:
-                                      Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    description:
-                                      Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
-                                    type: string
-                                required:
-                                  - port
-                                type: object
-                              tcpSocket:
-                                description:
-                                  "TCPSocket specifies an action involving
-                                  a TCP port. TCP hooks not yet supported TODO: implement
-                                  a realistic TCP lifecycle hook"
-                                properties:
-                                  host:
-                                    description:
-                                      "Optional: Host name to connect to,
-                                      defaults to the pod IP."
-                                    type: string
-                                  port:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description:
-                                      Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                  - port
-                                type: object
-                            type: object
-                        type: object
-                      livenessProbe:
-                        description:
-                          "Periodic probe of container liveness. Container
-                          will be restarted if the probe fails. Cannot be updated. More
-                          info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                        properties:
-                          exec:
-                            description:
-                              One and only one of the following should be
-                              specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description:
-                                  Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description:
-                              Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
+                          containerPort:
+                            description: Number of port to expose on the pod's IP
+                              address. This must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description:
-                                  Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description:
-                                  Custom headers to set in the request. HTTP
-                                  allows repeated headers.
-                                items:
-                                  description:
-                                    HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description:
-                                  Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description:
-                                  Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description:
-                              "Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description:
-                              How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description:
-                              Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description:
-                              "TCPSocket specifies an action involving a
-                              TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook"
-                            properties:
-                              host:
-                                description:
-                                  "Optional: Host name to connect to, defaults
-                                  to the pod IP."
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description:
-                                  Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description:
-                              "Number of seconds after which the probe times
-                              out. Defaults to 1 second. Minimum value is 1. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        description:
-                          Name of the container specified as a DNS_LABEL.
-                          Each container in a pod must have a unique name (DNS_LABEL).
-                          Cannot be updated.
-                        type: string
-                      ports:
-                        description:
-                          List of ports to expose from the container. Exposing
-                          a port here gives the system additional information about
-                          the network connections a container uses, but is primarily
-                          informational. Not specifying a port here DOES NOT prevent
-                          that port from being exposed. Any port which is listening
-                          on the default "0.0.0.0" address inside a container will be
-                          accessible from the network. Cannot be updated.
-                        items:
-                          description:
-                            ContainerPort represents a network port in a
-                            single container.
-                          properties:
-                            containerPort:
-                              description:
-                                Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x < 65536.
-                              format: int32
-                              type: integer
-                            hostIP:
-                              description: What host IP to bind the external port to.
-                              type: string
-                            hostPort:
-                              description:
-                                Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x <
-                                65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
-                              format: int32
-                              type: integer
-                            name:
-                              description:
-                                If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
-                              type: string
-                            protocol:
-                              default: TCP
-                              description:
-                                Protocol for port. Must be UDP, TCP, or SCTP.
-                                Defaults to "TCP".
-                              type: string
-                          required:
-                            - containerPort
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                          - containerPort
-                          - protocol
-                        x-kubernetes-list-type: map
-                      readinessProbe:
-                        description:
-                          "Periodic probe of container service readiness.
-                          Container will be removed from service endpoints if the probe
-                          fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                        properties:
-                          exec:
-                            description:
-                              One and only one of the following should be
-                              specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description:
-                                  Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description:
-                              Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description:
-                                  Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description:
-                                  Custom headers to set in the request. HTTP
-                                  allows repeated headers.
-                                items:
-                                  description:
-                                    HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description:
-                                  Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description:
-                                  Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description:
-                              "Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description:
-                              How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description:
-                              Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description:
-                              "TCPSocket specifies an action involving a
-                              TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook"
-                            properties:
-                              host:
-                                description:
-                                  "Optional: Host name to connect to, defaults
-                                  to the pod IP."
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description:
-                                  Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description:
-                              "Number of seconds after which the probe times
-                              out. Defaults to 1 second. Minimum value is 1. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        description:
-                          "Compute Resources required by this container.
-                          Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description:
-                              "Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description:
-                              "Requests describes the minimum amount of compute
-                              resources required. If Requests is omitted for a container,
-                              it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. More info:
-                              https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
-                            type: object
-                        type: object
-                      securityContext:
-                        description:
-                          "Security options the pod should run with. More
-                          info: https://kubernetes.io/docs/concepts/policy/security-context/
-                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
-                        properties:
-                          allowPrivilegeEscalation:
-                            description:
-                              "AllowPrivilegeEscalation controls whether
-                              a process can gain more privileges than its parent process.
-                              This bool directly controls if the no_new_privs flag will
-                              be set on the container process. AllowPrivilegeEscalation
-                              is true always when the container is: 1) run as Privileged
-                              2) has CAP_SYS_ADMIN"
-                            type: boolean
-                          capabilities:
-                            description:
-                              The capabilities to add/drop when running containers.
-                              Defaults to the default set of capabilities granted by
-                              the container runtime.
-                            properties:
-                              add:
-                                description: Added capabilities
-                                items:
-                                  description:
-                                    Capability represent POSIX capabilities
-                                    type
-                                  type: string
-                                type: array
-                              drop:
-                                description: Removed capabilities
-                                items:
-                                  description:
-                                    Capability represent POSIX capabilities
-                                    type
-                                  type: string
-                                type: array
-                            type: object
-                          privileged:
-                            description:
-                              Run container in privileged mode. Processes
-                              in privileged containers are essentially equivalent to
-                              root on the host. Defaults to false.
-                            type: boolean
-                          procMount:
-                            description:
-                              procMount denotes the type of proc mount to
-                              use for the containers. The default is DefaultProcMount
-                              which uses the container runtime defaults for readonly
-                              paths and masked paths. This requires the ProcMountType
-                              feature flag to be enabled.
+                          hostIP:
+                            description: What host IP to bind the external port to.
                             type: string
-                          readOnlyRootFilesystem:
-                            description:
-                              Whether this container has a read-only root
-                              filesystem. Default is false.
-                            type: boolean
-                          runAsGroup:
-                            description:
-                              The GID to run the entrypoint of the container
-                              process. Uses runtime default if unset. May also be set
-                              in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence.
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
-                            description:
-                              Indicates that the container must run as a
-                              non-root user. If true, the Kubelet will validate the
-                              image at runtime to ensure that it does not run as UID
-                              0 (root) and fail to start the container if it does. If
-                              unset or false, no such validation will be performed.
-                              May also be set in PodSecurityContext.  If set in both
-                              SecurityContext and PodSecurityContext, the value specified
-                              in SecurityContext takes precedence.
-                            type: boolean
-                          runAsUser:
-                            description:
-                              The UID to run the entrypoint of the container
-                              process. Defaults to user specified in image metadata
-                              if unspecified. May also be set in PodSecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext, the
-                              value specified in SecurityContext takes precedence.
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
-                            description:
-                              The SELinux context to be applied to the container.
-                              If unspecified, the container runtime will allocate a
-                              random SELinux context for each container.  May also be
-                              set in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence.
-                            properties:
-                              level:
-                                description:
-                                  Level is SELinux level label that applies
-                                  to the container.
-                                type: string
-                              role:
-                                description:
-                                  Role is a SELinux role label that applies
-                                  to the container.
-                                type: string
-                              type:
-                                description:
-                                  Type is a SELinux type label that applies
-                                  to the container.
-                                type: string
-                              user:
-                                description:
-                                  User is a SELinux user label that applies
-                                  to the container.
-                                type: string
-                            type: object
-                          seccompProfile:
-                            description:
-                              The seccomp options to use by this container.
-                              If seccomp options are provided at both the pod & container
-                              level, the container options override the pod options.
-                            properties:
-                              localhostProfile:
-                                description:
-                                  localhostProfile indicates a profile defined
-                                  in a file on the node should be used. The profile
-                                  must be preconfigured on the node to work. Must be
-                                  a descending path, relative to the kubelet's configured
-                                  seccomp profile location. Must only be set if type
-                                  is "Localhost".
-                                type: string
-                              type:
-                                description:
-                                  "type indicates which kind of seccomp profile
-                                  will be applied. Valid options are: \n Localhost -
-                                  a profile defined in a file on the node should be
-                                  used. RuntimeDefault - the container runtime default
-                                  profile should be used. Unconfined - no profile should
-                                  be applied."
-                                type: string
-                            required:
-                              - type
-                            type: object
-                          windowsOptions:
-                            description:
-                              The Windows specific settings applied to all
-                              containers. If unspecified, the options from the PodSecurityContext
-                              will be used. If set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence.
-                            properties:
-                              gmsaCredentialSpec:
-                                description:
-                                  GMSACredentialSpec is where the GMSA admission
-                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                  inlines the contents of the GMSA credential spec named
-                                  by the GMSACredentialSpecName field.
-                                type: string
-                              gmsaCredentialSpecName:
-                                description:
-                                  GMSACredentialSpecName is the name of the
-                                  GMSA credential spec to use.
-                                type: string
-                              runAsUserName:
-                                description:
-                                  The UserName in Windows to run the entrypoint
-                                  of the container process. Defaults to the user specified
-                                  in image metadata if unspecified. May also be set
-                                  in PodSecurityContext. If set in both SecurityContext
-                                  and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence.
-                                type: string
-                            type: object
-                        type: object
-                      startupProbe:
-                        description:
-                          "StartupProbe indicates that the Pod has successfully
-                          initialized. If specified, no other probes are executed until
-                          this completes successfully. If this probe fails, the Pod
-                          will be restarted, just as if the livenessProbe failed. This
-                          can be used to provide different probe parameters at the beginning
-                          of a Pod's lifecycle, when it might take a long time to load
-                          data or warm a cache, than during steady-state operation.
-                          This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                        properties:
-                          exec:
-                            description:
-                              One and only one of the following should be
-                              specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description:
-                                  Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description:
-                              Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
+                          hostPort:
+                            description: Number of port to expose on the host. If
+                              specified, this must be a valid port number, 0 < x <
+                              65536. If HostNetwork is specified, this must match
+                              ContainerPort. Most containers do not need this.
                             format: int32
                             type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description:
-                                  Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description:
-                                  Custom headers to set in the request. HTTP
-                                  allows repeated headers.
-                                items:
-                                  description:
-                                    HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description:
-                                  Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description:
-                                  Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description:
-                              "Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description:
-                              How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description:
-                              Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description:
-                              "TCPSocket specifies an action involving a
-                              TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook"
-                            properties:
-                              host:
-                                description:
-                                  "Optional: Host name to connect to, defaults
-                                  to the pod IP."
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description:
-                                  Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description:
-                              "Number of seconds after which the probe times
-                              out. Defaults to 1 second. Minimum value is 1. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
-                            format: int32
-                            type: integer
-                        type: object
-                      stdin:
-                        description:
-                          Whether this container should allocate a buffer
-                          for stdin in the container runtime. If this is not set, reads
-                          from stdin in the container will always result in EOF. Default
-                          is false.
-                        type: boolean
-                      stdinOnce:
-                        description:
-                          Whether the container runtime should close the
-                          stdin channel after it has been opened by a single attach.
-                          When stdin is true the stdin stream will remain open across
-                          multiple attach sessions. If stdinOnce is set to true, stdin
-                          is opened on container start, is empty until the first client
-                          attaches to stdin, and then remains open and accepts data
-                          until the client disconnects, at which time stdin is closed
-                          and remains closed until the container is restarted. If this
-                          flag is false, a container processes that reads from stdin
-                          will never receive an EOF. Default is false
-                        type: boolean
-                      terminationMessagePath:
-                        description:
-                          "Optional: Path at which the file to which the
-                          container's termination message will be written is mounted
-                          into the container's filesystem. Message written is intended
-                          to be brief final status, such as an assertion failure message.
-                          Will be truncated by the node if greater than 4096 bytes.
-                          The total message length across all containers will be limited
-                          to 12kb. Defaults to /dev/termination-log. Cannot be updated."
-                        type: string
-                      terminationMessagePolicy:
-                        description:
-                          Indicate how the termination message should be
-                          populated. File will use the contents of terminationMessagePath
-                          to populate the container status message on both success and
-                          failure. FallbackToLogsOnError will use the last chunk of
-                          container log output if the termination message file is empty
-                          and the container exited with an error. The log output is
-                          limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
-                          to File. Cannot be updated.
-                        type: string
-                      tty:
-                        description:
-                          Whether this container should allocate a TTY for
-                          itself, also requires 'stdin' to be true. Default is false.
-                        type: boolean
-                      volumeDevices:
-                        description:
-                          volumeDevices is the list of block devices to be
-                          used by the container.
-                        items:
-                          description:
-                            volumeDevice describes a mapping of a raw block
-                            device within a container.
-                          properties:
-                            devicePath:
-                              description:
-                                devicePath is the path inside of the container
-                                that the device will be mapped to.
-                              type: string
-                            name:
-                              description:
-                                name must match the name of a persistentVolumeClaim
-                                in the pod
-                              type: string
-                          required:
-                            - devicePath
-                            - name
-                          type: object
-                        type: array
-                      volumeMounts:
-                        description:
-                          Pod volumes to mount into the container's filesystem.
-                          Cannot be updated.
-                        items:
-                          description:
-                            VolumeMount describes a mounting of a Volume
-                            within a container.
-                          properties:
-                            mountPath:
-                              description:
-                                Path within the container at which the volume
-                                should be mounted.  Must not contain ':'.
-                              type: string
-                            mountPropagation:
-                              description:
-                                mountPropagation determines how mounts are
-                                propagated from the host to container and the other
-                                way around. When not set, MountPropagationNone is used.
-                                This field is beta in 1.10.
-                              type: string
-                            name:
-                              description: This must match the Name of a Volume.
-                              type: string
-                            readOnly:
-                              description:
-                                Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
-                              type: boolean
-                            subPath:
-                              description:
-                                Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's root).
-                              type: string
-                            subPathExpr:
-                              description:
-                                Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves similarly
-                                to SubPath but environment variable references $(VAR_NAME)
-                                are expanded using the container's environment. Defaults
-                                to "" (volume's root). SubPathExpr and SubPath are mutually
-                                exclusive.
-                              type: string
-                          required:
-                            - mountPath
-                            - name
-                          type: object
-                        type: array
-                      workingDir:
-                        description:
-                          Container's working directory. If not specified,
-                          the container runtime's default will be used, which might
-                          be configured in the container image. Cannot be updated.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                type:
-                  description:
-                    type defines if the cluster is internal (i.e manager
-                    by the operator) or external.
-                  enum:
-                    - external
-                    - internal
-                  type: string
-                zkAddress:
-                  description:
-                    "zKAddress specifies the ZooKeeper connection string
-                    in the form hostname:port where host and port are those of a Zookeeper
-                    server. TODO: rework for nice zookeeper connect string ="
-                  type: string
-                zkPath:
-                  description:
-                    zKPath specifies the Zookeeper chroot path as part of
-                    its Zookeeper connection string which puts its data under same path
-                    in the global ZooKeeper namespace.
-                  type: string
-              required:
-                - nodes
-              type: object
-            status:
-              description: NifiClusterStatus defines the observed state of NifiCluster
-              properties:
-                nodesState:
-                  additionalProperties:
-                    description: NifiState holds information about nifi state
-                    properties:
-                      configurationState:
-                        description: ConfigurationState holds info about the config
-                        type: string
-                      gracefulActionState:
-                        description:
-                          GracefulActionState holds info about nifi cluster
-                          action status
-                        properties:
-                          TaskStarted:
-                            description:
-                              TaskStarted hold the time when the execution
-                              started
+                          name:
+                            description: If specified, this must be an IANA_SVC_NAME
+                              and unique within the pod. Each named port in a pod
+                              must have a unique name. Name for the port that can
+                              be referred to by services.
                             type: string
-                          actionState:
-                            description:
-                              ActionState holds the information about Action
-                              state
-                            type: string
-                          actionStep:
-                            description:
-                              ActionStep holds info about the action step
-                              ran
-                            type: string
-                          errorMessage:
-                            description:
-                              ErrorMessage holds the information what happened
-                              with Nifi Cluster
+                          protocol:
+                            default: TCP
+                            description: Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
                             type: string
                         required:
-                          - actionState
-                          - errorMessage
+                        - containerPort
                         type: object
-                      initClusterNode:
-                        description:
-                          InitClusterNode contains if this nodes was part
-                          of the initial cluster
-                        type: boolean
-                      podIsReady:
-                        description:
-                          PodIsReady whether or not the associated pod is
-                          ready
-                        type: boolean
-                    required:
-                      - configurationState
-                      - gracefulActionState
-                      - initClusterNode
-                      - podIsReady
-                    type: object
-                  description: Store the state of each nifi node
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - containerPort
+                      - protocol
+                      x-kubernetes-list-type: map
+                    readinessProbe:
+                      description: 'Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe
+                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                    resources:
+                      description: 'Compute Resources required by this container.
+                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    securityContext:
+                      description: 'Security options the pod should run with. More
+                        info: https://kubernetes.io/docs/concepts/policy/security-context/
+                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                      properties:
+                        allowPrivilegeEscalation:
+                          description: 'AllowPrivilegeEscalation controls whether
+                            a process can gain more privileges than its parent process.
+                            This bool directly controls if the no_new_privs flag will
+                            be set on the container process. AllowPrivilegeEscalation
+                            is true always when the container is: 1) run as Privileged
+                            2) has CAP_SYS_ADMIN'
+                          type: boolean
+                        capabilities:
+                          description: The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by
+                            the container runtime.
+                          properties:
+                            add:
+                              description: Added capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                            drop:
+                              description: Removed capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                          type: object
+                        privileged:
+                          description: Run container in privileged mode. Processes
+                            in privileged containers are essentially equivalent to
+                            root on the host. Defaults to false.
+                          type: boolean
+                        procMount:
+                          description: procMount denotes the type of proc mount to
+                            use for the containers. The default is DefaultProcMount
+                            which uses the container runtime defaults for readonly
+                            paths and masked paths. This requires the ProcMountType
+                            feature flag to be enabled.
+                          type: string
+                        readOnlyRootFilesystem:
+                          description: Whether this container has a read-only root
+                            filesystem. Default is false.
+                          type: boolean
+                        runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both
+                            SecurityContext and PodSecurityContext, the value specified
+                            in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in PodSecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: The seccomp options to use by this container.
+                            If seccomp options are provided at both the pod & container
+                            level, the container options override the pod options.
+                          properties:
+                            localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile
+                                must be preconfigured on the node to work. Must be
+                                a descending path, relative to the kubelet's configured
+                                seccomp profile location. Must only be set if type
+                                is "Localhost".
+                              type: string
+                            type:
+                              description: "type indicates which kind of seccomp profile
+                                will be applied. Valid options are: \n Localhost -
+                                a profile defined in a file on the node should be
+                                used. RuntimeDefault - the container runtime default
+                                profile should be used. Unconfined - no profile should
+                                be applied."
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options from the PodSecurityContext
+                            will be used. If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    startupProbe:
+                      description: 'StartupProbe indicates that the Pod has successfully
+                        initialized. If specified, no other probes are executed until
+                        this completes successfully. If this probe fails, the Pod
+                        will be restarted, just as if the livenessProbe failed. This
+                        can be used to provide different probe parameters at the beginning
+                        of a Pod''s lifecycle, when it might take a long time to load
+                        data or warm a cache, than during steady-state operation.
+                        This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                    stdin:
+                      description: Whether this container should allocate a buffer
+                        for stdin in the container runtime. If this is not set, reads
+                        from stdin in the container will always result in EOF. Default
+                        is false.
+                      type: boolean
+                    stdinOnce:
+                      description: Whether the container runtime should close the
+                        stdin channel after it has been opened by a single attach.
+                        When stdin is true the stdin stream will remain open across
+                        multiple attach sessions. If stdinOnce is set to true, stdin
+                        is opened on container start, is empty until the first client
+                        attaches to stdin, and then remains open and accepts data
+                        until the client disconnects, at which time stdin is closed
+                        and remains closed until the container is restarted. If this
+                        flag is false, a container processes that reads from stdin
+                        will never receive an EOF. Default is false
+                      type: boolean
+                    terminationMessagePath:
+                      description: 'Optional: Path at which the file to which the
+                        container''s termination message will be written is mounted
+                        into the container''s filesystem. Message written is intended
+                        to be brief final status, such as an assertion failure message.
+                        Will be truncated by the node if greater than 4096 bytes.
+                        The total message length across all containers will be limited
+                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                      type: string
+                    terminationMessagePolicy:
+                      description: Indicate how the termination message should be
+                        populated. File will use the contents of terminationMessagePath
+                        to populate the container status message on both success and
+                        failure. FallbackToLogsOnError will use the last chunk of
+                        container log output if the termination message file is empty
+                        and the container exited with an error. The log output is
+                        limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
+                        to File. Cannot be updated.
+                      type: string
+                    tty:
+                      description: Whether this container should allocate a TTY for
+                        itself, also requires 'stdin' to be true. Default is false.
+                      type: boolean
+                    volumeDevices:
+                      description: volumeDevices is the list of block devices to be
+                        used by the container.
+                      items:
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
+                        properties:
+                          devicePath:
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
+                            type: string
+                          name:
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
+                            type: string
+                        required:
+                        - devicePath
+                        - name
+                        type: object
+                      type: array
+                    volumeMounts:
+                      description: Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
+                      items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume
+                              should be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are
+                              propagated from the host to container and the other
+                              way around. When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted. Behaves similarly
+                              to SubPath but environment variable references $(VAR_NAME)
+                              are expanded using the container's environment. Defaults
+                              to "" (volume's root). SubPathExpr and SubPath are mutually
+                              exclusive.
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
+                    workingDir:
+                      description: Container's working directory. If not specified,
+                        the container runtime's default will be used, which might
+                        be configured in the container image. Cannot be updated.
+                      type: string
+                  required:
+                  - name
                   type: object
-                prometheusReportingTask:
-                  description:
-                    PrometheusReportingTask contains the status of the prometheus
-                    reporting task managed by the operator
+                type: array
+              ldapConfiguration:
+                description: LdapConfiguration specifies the configuration if you
+                  want to use LDAP
+                properties:
+                  enabled:
+                    description: If set to true, we will enable ldap usage into nifi.properties
+                      configuration.
+                    type: boolean
+                  searchBase:
+                    description: Base DN for searching for users (i.e. CN=Users,DC=example,DC=com).
+                    type: string
+                  searchFilter:
+                    description: Filter for searching for users against the 'User
+                      Search Base'. (i.e. sAMAccountName={0}). The user specified
+                      name is inserted into '{0}'.
+                    type: string
+                  url:
+                    description: Space-separated list of URLs of the LDAP servers
+                      (i.e. ldap://<hostname>:<port>).
+                    type: string
+                type: object
+              listenersConfig:
+                description: "TODO : add vault VaultConfig         \tVaultConfig         `json:\"vaultConfig,omitempty\"`
+                  listenerConfig specifies nifi's listener specifig configs"
+                properties:
+                  clusterDomain:
+                    description: clusterDomain allow to override the default cluster
+                      domain which is "cluster.local"
+                    type: string
+                  internalListeners:
+                    description: internalListeners specifies settings required to
+                      access nifi internally
+                    items:
+                      description: InternalListenerConfig defines the internal listener
+                        config for Nifi
+                      properties:
+                        containerPort:
+                          description: The container port.
+                          format: int32
+                          type: integer
+                        name:
+                          description: An identifier for the port which will be configured.
+                          type: string
+                        type:
+                          description: (Optional field) Type allow to specify if we
+                            are in a specific nifi listener it's allowing to define
+                            some required information such as Cluster Port, Http Port,
+                            Https Port or S2S port
+                          enum:
+                          - cluster
+                          - http
+                          - https
+                          - s2s
+                          - prometheus
+                          type: string
+                      required:
+                      - containerPort
+                      - name
+                      type: object
+                    type: array
+                  sslSecrets:
+                    description: sslSecrets contains information about ssl related
+                      kubernetes secrets if one of the listener setting type set to
+                      ssl these fields must be populated to
+                    properties:
+                      clusterScoped:
+                        description: clusterScoped defines if the Issuer created is
+                          cluster or namespace scoped
+                        type: boolean
+                      create:
+                        description: create tells the installed cert manager to create
+                          the required certs keys
+                        type: boolean
+                      issuerRef:
+                        description: 'issuerRef allow to use an existing issuer to
+                          act as CA : https://cert-manager.io/docs/concepts/issuer/'
+                        properties:
+                          group:
+                            description: Group of the resource being referred to.
+                            type: string
+                          kind:
+                            description: Kind of the resource being referred to.
+                            type: string
+                          name:
+                            description: Name of the resource being referred to.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      pkiBackend:
+                        description: 'TODO : add vault'
+                        enum:
+                        - cert-manager
+                        - vault
+                        type: string
+                      tlsSecretName:
+                        description: 'tlsSecretName should contain all ssl certs required
+                          by nifi including: caCert, caKey, clientCert, clientKey
+                          serverCert, serverKey, peerCert, peerKey'
+                        type: string
+                    required:
+                    - tlsSecretName
+                    type: object
+                  useExternalDNS:
+                    description: 'useExternalDNS allow to manage externalDNS usage
+                      by limiting the DNS names associated to each nodes and load
+                      balancer : <cluster-name>-node-<node Id>.<cluster-name>.<service
+                      name>.<cluster domain>'
+                    type: boolean
+                required:
+                - internalListeners
+                type: object
+              managedAdminUsers:
+                description: managedAdminUsers contains the list of users that will
+                  be added to the managed admin group (with all rights)
+                items:
+                  properties:
+                    identity:
+                      description: identity field is use to define the user identity
+                        on NiFi cluster side, it use full when the user's name doesn't
+                        suite with Kubernetes resource name.
+                      type: string
+                    name:
+                      description: name field is use to name the NifiUser resource,
+                        if not identity is provided it will be used to name the user
+                        on NiFi cluster side.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              managedReaderUsers:
+                description: managedReaderUsers contains the list of users that will
+                  be added to the managed reader group (with all view rights)
+                items:
+                  properties:
+                    identity:
+                      description: identity field is use to define the user identity
+                        on NiFi cluster side, it use full when the user's name doesn't
+                        suite with Kubernetes resource name.
+                      type: string
+                    name:
+                      description: name field is use to name the NifiUser resource,
+                        if not identity is provided it will be used to name the user
+                        on NiFi cluster side.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              nifiClusterTaskSpec:
+                description: NifiClusterTaskSpec specifies the configuration of the
+                  nifi cluster Tasks
+                properties:
+                  retryDurationMinutes:
+                    description: RetryDurationMinutes describes the amount of time
+                      the Operator waits for the task
+                    type: integer
+                required:
+                - retryDurationMinutes
+                type: object
+              nifiURI:
+                description: nifiURI used access through a LB uri (used if external
+                  type)
+                type: string
+              nodeConfigGroups:
+                additionalProperties:
+                  description: NodeConfig defines the node configuration
+                  properties:
+                    fsGroup:
+                      description: FSGroup define the id of the group for each volumes
+                        in Nifi image
+                      format: int64
+                      minimum: 1
+                      type: integer
+                    image:
+                      description: ' Docker image used by the operator to create the
+                        node associated  https://hub.docker.com/r/apache/nifi/'
+                      type: string
+                    imagePullPolicy:
+                      description: imagePullPolicy define the pull policy for NiFi
+                        cluster docker image
+                      type: string
+                    imagePullSecrets:
+                      description: imagePullSecrets specifies the secret to use when
+                        using private registry https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#localobjectreference-v1-core
+                      items:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      type: array
+                    isNode:
+                      description: Set this to true if the instance is a node in a
+                        cluster. https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#basic-cluster-setup
+                      type: boolean
+                    nifiAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: Additionnal annotation to attach to the pod associated
+                        https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+                      type: object
+                    nodeAffinity:
+                      description: nodeAffinity can be specified, operator populates
+                        this value if new pvc added later to node
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods
+                            to nodes that satisfy the affinity expressions specified
+                            by this field, but it may choose a node that violates
+                            one or more of the expressions. The node that is most
+                            preferred is the one with the greatest sum of weights,
+                            i.e. for each node that meets all of the scheduling requirements
+                            (resource request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements
+                            of this field and adding "weight" to the sum if the node
+                            matches the corresponding matchExpressions; the node(s)
+                            with the highest sum are the most preferred.
+                          items:
+                            description: An empty preferred scheduling term matches
+                              all objects with implicit weight 0 (i.e. it's a no-op).
+                              A null preferred scheduling term matches no objects
+                              (i.e. is also a no-op).
+                            properties:
+                              preference:
+                                description: A node selector term, associated with
+                                  the corresponding weight.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              weight:
+                                description: Weight associated with matching the corresponding
+                                  nodeSelectorTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                            - preference
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not
+                            be scheduled onto the node. If the affinity requirements
+                            specified by this field cease to be met at some point
+                            during pod execution (e.g. due to an update), the system
+                            may or may not try to eventually evict the pod from its
+                            node.
+                          properties:
+                            nodeSelectorTerms:
+                              description: Required. A list of node selector terms.
+                                The terms are ORed.
+                              items:
+                                description: A null or empty node selector term matches
+                                  no objects. The requirements of them are ANDed.
+                                  The TopologySelectorTerm type implements a subset
+                                  of the NodeSelectorTerm.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          required:
+                          - nodeSelectorTerms
+                          type: object
+                      type: object
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: nodeSelector can be specified, which set the pod
+                        to fit on a node https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+                      type: object
+                    provenanceStorage:
+                      description: provenanceStorage allow to specify the maximum
+                        amount of data provenance information to store at a time https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#write-ahead-provenance-repository-properties
+                      type: string
+                    resourcesRequirements:
+                      description: resourceRequirements works exactly like Container
+                        resources, the user can specify the limit and the requests
+                        through this property https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    runAsUser:
+                      description: RunAsUser define the id of the user to run in the
+                        Nifi image
+                      format: int64
+                      minimum: 1
+                      type: integer
+                    serviceAccountName:
+                      description: serviceAccountName specifies the serviceAccount
+                        used for this specific node
+                      type: string
+                    storageConfigs:
+                      description: storageConfigs specifies the node related configs
+                      items:
+                        description: StorageConfig defines the node storage configuration
+                        properties:
+                          mountPath:
+                            description: Path where the volume will be mount into
+                              the main nifi container inside the pod.
+                            type: string
+                          name:
+                            description: Name of the storage config, used to name
+                              PV to reuse into sidecars for example.
+                            pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
+                            type: string
+                          pvcSpec:
+                            description: Kubernetes PVC spec
+                            properties:
+                              accessModes:
+                                description: 'AccessModes contains the desired access
+                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                items:
+                                  type: string
+                                type: array
+                              dataSource:
+                                description: 'This field can be used to specify either:
+                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                  * An existing PVC (PersistentVolumeClaim) * An existing
+                                  custom resource that implements data population
+                                  (Alpha) In order to use custom resource types that
+                                  implement data population, the AnyVolumeDataSource
+                                  feature gate must be enabled. If the provisioner
+                                  or an external controller can support the specified
+                                  data source, it will create a new volume based on
+                                  the contents of the specified data source.'
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup is the group for the resource
+                                      being referenced. If APIGroup is not specified,
+                                      the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is
+                                      required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being
+                                      referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being
+                                      referenced
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              resources:
+                                description: 'Resources represents the minimum resources
+                                  the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. More info:
+                                      https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                type: object
+                              selector:
+                                description: A label query over volumes to consider
+                                  for binding.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              storageClassName:
+                                description: 'Name of the StorageClass required by
+                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                type: string
+                              volumeMode:
+                                description: volumeMode defines what type of volume
+                                  is required by the claim. Value of Filesystem is
+                                  implied when not included in claim spec.
+                                type: string
+                              volumeName:
+                                description: VolumeName is the binding reference to
+                                  the PersistentVolume backing this claim.
+                                type: string
+                            type: object
+                        required:
+                        - mountPath
+                        - name
+                        - pvcSpec
+                        type: object
+                      type: array
+                    tolerations:
+                      description: tolerations can be specified, which set the pod's
+                        tolerations https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/#concepts
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified,
+                              allowed values are NoSchedule, PreferNoSchedule and
+                              NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship
+                              to the value. Valid operators are Exists and Equal.
+                              Defaults to Equal. Exists is equivalent to wildcard
+                              for value, so that a pod can tolerate all taints of
+                              a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                description: nodeConfigGroups specifies multiple node configs with
+                  unique name
+                type: object
+              nodeURITemplate:
+                description: nodeURITemplate used to dynamically compute node uri
+                  (used if external type)
+                type: string
+              nodes:
+                description: all node requires an image, unique id, and storageConfigs
+                  settings
+                items:
+                  description: Node defines the nifi node basic configuration
                   properties:
                     id:
-                      description: The nifi reporting task's id
-                      type: string
-                    version:
-                      description: The last nifi reporting task revision version catched
-                      format: int64
+                      description: Unique Node id
+                      format: int32
                       type: integer
+                    nodeConfig:
+                      description: node configuration
+                      properties:
+                        fsGroup:
+                          description: FSGroup define the id of the group for each
+                            volumes in Nifi image
+                          format: int64
+                          minimum: 1
+                          type: integer
+                        image:
+                          description: ' Docker image used by the operator to create
+                            the node associated  https://hub.docker.com/r/apache/nifi/'
+                          type: string
+                        imagePullPolicy:
+                          description: imagePullPolicy define the pull policy for
+                            NiFi cluster docker image
+                          type: string
+                        imagePullSecrets:
+                          description: imagePullSecrets specifies the secret to use
+                            when using private registry https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#localobjectreference-v1-core
+                          items:
+                            description: LocalObjectReference contains enough information
+                              to let you locate the referenced object inside the same
+                              namespace.
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                            type: object
+                          type: array
+                        isNode:
+                          description: Set this to true if the instance is a node
+                            in a cluster. https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#basic-cluster-setup
+                          type: boolean
+                        nifiAnnotations:
+                          additionalProperties:
+                            type: string
+                          description: Additionnal annotation to attach to the pod
+                            associated https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+                          type: object
+                        nodeAffinity:
+                          description: nodeAffinity can be specified, operator populates
+                            this value if new pvc added later to node
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a
+                                  no-op). A null preferred scheduling term matches
+                                  no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - preference
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an
+                                update), the system may or may not try to eventually
+                                evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them
+                                      are ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          description: nodeSelector can be specified, which set the
+                            pod to fit on a node https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+                          type: object
+                        provenanceStorage:
+                          description: provenanceStorage allow to specify the maximum
+                            amount of data provenance information to store at a time
+                            https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#write-ahead-provenance-repository-properties
+                          type: string
+                        resourcesRequirements:
+                          description: resourceRequirements works exactly like Container
+                            resources, the user can specify the limit and the requests
+                            through this property https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runAsUser:
+                          description: RunAsUser define the id of the user to run
+                            in the Nifi image
+                          format: int64
+                          minimum: 1
+                          type: integer
+                        serviceAccountName:
+                          description: serviceAccountName specifies the serviceAccount
+                            used for this specific node
+                          type: string
+                        storageConfigs:
+                          description: storageConfigs specifies the node related configs
+                          items:
+                            description: StorageConfig defines the node storage configuration
+                            properties:
+                              mountPath:
+                                description: Path where the volume will be mount into
+                                  the main nifi container inside the pod.
+                                type: string
+                              name:
+                                description: Name of the storage config, used to name
+                                  PV to reuse into sidecars for example.
+                                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
+                                type: string
+                              pvcSpec:
+                                description: Kubernetes PVC spec
+                                properties:
+                                  accessModes:
+                                    description: 'AccessModes contains the desired
+                                      access modes the volume should have. More info:
+                                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    description: 'This field can be used to specify
+                                      either: * An existing VolumeSnapshot object
+                                      (snapshot.storage.k8s.io/VolumeSnapshot) * An
+                                      existing PVC (PersistentVolumeClaim) * An existing
+                                      custom resource that implements data population
+                                      (Alpha) In order to use custom resource types
+                                      that implement data population, the AnyVolumeDataSource
+                                      feature gate must be enabled. If the provisioner
+                                      or an external controller can support the specified
+                                      data source, it will create a new volume based
+                                      on the contents of the specified data source.'
+                                    properties:
+                                      apiGroup:
+                                        description: APIGroup is the group for the
+                                          resource being referenced. If APIGroup is
+                                          not specified, the specified Kind must be
+                                          in the core API group. For any other third-party
+                                          types, APIGroup is required.
+                                        type: string
+                                      kind:
+                                        description: Kind is the type of resource
+                                          being referenced
+                                        type: string
+                                      name:
+                                        description: Name is the name of resource
+                                          being referenced
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                  resources:
+                                    description: 'Resources represents the minimum
+                                      resources the volume should have. More info:
+                                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                    type: object
+                                  selector:
+                                    description: A label query over volumes to consider
+                                      for binding.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  storageClassName:
+                                    description: 'Name of the StorageClass required
+                                      by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                    type: string
+                                  volumeMode:
+                                    description: volumeMode defines what type of volume
+                                      is required by the claim. Value of Filesystem
+                                      is implied when not included in claim spec.
+                                    type: string
+                                  volumeName:
+                                    description: VolumeName is the binding reference
+                                      to the PersistentVolume backing this claim.
+                                    type: string
+                                type: object
+                            required:
+                            - mountPath
+                            - name
+                            - pvcSpec
+                            type: object
+                          type: array
+                        tolerations:
+                          description: tolerations can be specified, which set the
+                            pod's tolerations https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/#concepts
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    nodeConfigGroup:
+                      description: nodeConfigGroup can be used to ease the node configuration,
+                        if set only the id is required
+                      type: string
+                    readOnlyConfig:
+                      description: readOnlyConfig can be used to pass Nifi node config
+                        https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html
+                        which has type read-only these config changes will trigger
+                        rolling upgrade
+                      properties:
+                        additionalSharedEnvs:
+                          description: AdditionalSharedEnvs define a set of additional
+                            env variables that will shared between all init containers
+                            and containers in the pod.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        bootstrapNotificationServicesConfig:
+                          description: BootstrapNotificationServices configuration
+                            that will be applied to the node.
+                          properties:
+                            replaceConfigMap:
+                              description: bootstrap_notifications_services.xml configuration
+                                that will replace the one produced based on template
+                              properties:
+                                data:
+                                  description: The key of the value,in data content,
+                                    that we want use.
+                                  type: string
+                                name:
+                                  description: Name of the configmap that we want
+                                    to refer.
+                                  type: string
+                                namespace:
+                                  description: Namespace where is located the secret
+                                    that we want to refer.
+                                  type: string
+                              required:
+                              - data
+                              - name
+                              type: object
+                            replaceSecretConfig:
+                              description: bootstrap_notifications_services.xml configuration
+                                that will replace the one produced based on template
+                                and overrideConfigMap
+                              properties:
+                                data:
+                                  description: The key of the value,in data content,
+                                    that we want use.
+                                  type: string
+                                name:
+                                  description: Name of the configmap that we want
+                                    to refer.
+                                  type: string
+                                namespace:
+                                  description: Namespace where is located the secret
+                                    that we want to refer.
+                                  type: string
+                              required:
+                              - data
+                              - name
+                              type: object
+                          type: object
+                        bootstrapProperties:
+                          description: BootstrapProperties configuration that will
+                            be applied to the node.
+                          properties:
+                            nifiJvmMemory:
+                              description: JVM memory settings
+                              type: string
+                            overrideConfigMap:
+                              description: Additionnals bootstrap.properties configuration
+                                that will override the one produced based on template
+                                and configuration
+                              properties:
+                                data:
+                                  description: The key of the value,in data content,
+                                    that we want use.
+                                  type: string
+                                name:
+                                  description: Name of the configmap that we want
+                                    to refer.
+                                  type: string
+                                namespace:
+                                  description: Namespace where is located the secret
+                                    that we want to refer.
+                                  type: string
+                              required:
+                              - data
+                              - name
+                              type: object
+                            overrideConfigs:
+                              description: Additionnals bootstrap.properties configuration
+                                that will override the one produced based on template
+                                and configurations.
+                              type: string
+                            overrideSecretConfig:
+                              description: Additionnals bootstrap.properties configuration
+                                that will override the one produced based on template,
+                                configurations, overrideConfigMap and overrideConfigs.
+                              properties:
+                                data:
+                                  description: The key of the value,in data content,
+                                    that we want use.
+                                  type: string
+                                name:
+                                  description: Name of the configmap that we want
+                                    to refer.
+                                  type: string
+                                namespace:
+                                  description: Namespace where is located the secret
+                                    that we want to refer.
+                                  type: string
+                              required:
+                              - data
+                              - name
+                              type: object
+                          type: object
+                        logbackConfig:
+                          description: Logback configuration that will be applied
+                            to the node.
+                          properties:
+                            replaceConfigMap:
+                              description: logback.xml configuration that will replace
+                                the one produced based on template
+                              properties:
+                                data:
+                                  description: The key of the value,in data content,
+                                    that we want use.
+                                  type: string
+                                name:
+                                  description: Name of the configmap that we want
+                                    to refer.
+                                  type: string
+                                namespace:
+                                  description: Namespace where is located the secret
+                                    that we want to refer.
+                                  type: string
+                              required:
+                              - data
+                              - name
+                              type: object
+                            replaceSecretConfig:
+                              description: logback.xml configuration that will replace
+                                the one produced based on template and overrideConfigMap
+                              properties:
+                                data:
+                                  description: The key of the value,in data content,
+                                    that we want use.
+                                  type: string
+                                name:
+                                  description: Name of the configmap that we want
+                                    to refer.
+                                  type: string
+                                namespace:
+                                  description: Namespace where is located the secret
+                                    that we want to refer.
+                                  type: string
+                              required:
+                              - data
+                              - name
+                              type: object
+                          type: object
+                        maximumTimerDrivenThreadCount:
+                          description: MaximumTimerDrivenThreadCount define the maximum
+                            number of threads for timer driven processors available
+                            to the system.
+                          format: int32
+                          type: integer
+                        nifiProperties:
+                          description: NifiProperties configuration that will be applied
+                            to the node.
+                          properties:
+                            authorizer:
+                              description: Indicates which of the configured authorizers
+                                in the authorizers.xml file to use https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#authorizer-configuration
+                              type: string
+                            needClientAuth:
+                              description: Nifi security client auth
+                              type: boolean
+                            overrideConfigMap:
+                              description: Additionnals nifi.properties configuration
+                                that will override the one produced based on template
+                                and configuration
+                              properties:
+                                data:
+                                  description: The key of the value,in data content,
+                                    that we want use.
+                                  type: string
+                                name:
+                                  description: Name of the configmap that we want
+                                    to refer.
+                                  type: string
+                                namespace:
+                                  description: Namespace where is located the secret
+                                    that we want to refer.
+                                  type: string
+                              required:
+                              - data
+                              - name
+                              type: object
+                            overrideConfigs:
+                              description: Additionnals nifi.properties configuration
+                                that will override the one produced based on template,
+                                configurations and overrideConfigMap.
+                              type: string
+                            overrideSecretConfig:
+                              description: Additionnals nifi.properties configuration
+                                that will override the one produced based on template,
+                                configurations, overrideConfigMap and overrideConfigs.
+                              properties:
+                                data:
+                                  description: The key of the value,in data content,
+                                    that we want use.
+                                  type: string
+                                name:
+                                  description: Name of the configmap that we want
+                                    to refer.
+                                  type: string
+                                namespace:
+                                  description: Namespace where is located the secret
+                                    that we want to refer.
+                                  type: string
+                              required:
+                              - data
+                              - name
+                              type: object
+                            webProxyHosts:
+                              description: A comma separated list of allowed HTTP
+                                Host header values to consider when NiFi is running
+                                securely and will be receiving requests to a different
+                                host[:port] than it is bound to. https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#web-properties
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        zookeeperProperties:
+                          description: ZookeeperProperties configuration that will
+                            be applied to the node.
+                          properties:
+                            overrideConfigMap:
+                              description: Additionnals zookeeper.properties configuration
+                                that will override the one produced based on template
+                                and configuration
+                              properties:
+                                data:
+                                  description: The key of the value,in data content,
+                                    that we want use.
+                                  type: string
+                                name:
+                                  description: Name of the configmap that we want
+                                    to refer.
+                                  type: string
+                                namespace:
+                                  description: Namespace where is located the secret
+                                    that we want to refer.
+                                  type: string
+                              required:
+                              - data
+                              - name
+                              type: object
+                            overrideConfigs:
+                              description: Additionnals zookeeper.properties configuration
+                                that will override the one produced based on template
+                                and configurations.
+                              type: string
+                            overrideSecretConfig:
+                              description: Additionnals zookeeper.properties configuration
+                                that will override the one produced based on template,
+                                configurations, overrideConfigMap and overrideConfigs.
+                              properties:
+                                data:
+                                  description: The key of the value,in data content,
+                                    that we want use.
+                                  type: string
+                                name:
+                                  description: Name of the configmap that we want
+                                    to refer.
+                                  type: string
+                                namespace:
+                                  description: Namespace where is located the secret
+                                    that we want to refer.
+                                  type: string
+                              required:
+                              - data
+                              - name
+                              type: object
+                          type: object
+                      type: object
                   required:
-                    - id
-                    - version
+                  - id
                   type: object
-                rollingUpgradeStatus:
-                  description: RollingUpgradeStatus defines status of rolling upgrade
+                type: array
+              oneNifiNodePerNode:
+                description: oneNifiNodePerNode if set to true every nifi node is
+                  started on a new node, if there is not enough node to do that it
+                  will stay in pending state. If set to false the operator also tries
+                  to schedule the nifi node to a unique node but if the node number
+                  is insufficient the nifi node will be scheduled to a node where
+                  a nifi node is already running.
+                type: boolean
+              pod:
+                description: Pod defines the policy for  pods owned by NiFiKop operator.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations specifies the annotations to attach to
+                      pods the operator creates
+                    type: object
+                type: object
+              propagateLabels:
+                description: propage
+                type: boolean
+              proxyUrl:
+                description: proxyUrl defines the proxy required to query the NiFi
+                  cluster (used if external type)
+                type: string
+              readOnlyConfig:
+                description: readOnlyConfig specifies the read-only type Nifi config
+                  cluster wide, all theses will be merged with node specified readOnly
+                  configurations, so it can be overwritten per node.
+                properties:
+                  additionalSharedEnvs:
+                    description: AdditionalSharedEnvs define a set of additional env
+                      variables that will shared between all init containers and containers
+                      in the pod.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  bootstrapNotificationServicesConfig:
+                    description: BootstrapNotificationServices configuration that
+                      will be applied to the node.
+                    properties:
+                      replaceConfigMap:
+                        description: bootstrap_notifications_services.xml configuration
+                          that will replace the one produced based on template
+                        properties:
+                          data:
+                            description: The key of the value,in data content, that
+                              we want use.
+                            type: string
+                          name:
+                            description: Name of the configmap that we want to refer.
+                            type: string
+                          namespace:
+                            description: Namespace where is located the secret that
+                              we want to refer.
+                            type: string
+                        required:
+                        - data
+                        - name
+                        type: object
+                      replaceSecretConfig:
+                        description: bootstrap_notifications_services.xml configuration
+                          that will replace the one produced based on template and
+                          overrideConfigMap
+                        properties:
+                          data:
+                            description: The key of the value,in data content, that
+                              we want use.
+                            type: string
+                          name:
+                            description: Name of the configmap that we want to refer.
+                            type: string
+                          namespace:
+                            description: Namespace where is located the secret that
+                              we want to refer.
+                            type: string
+                        required:
+                        - data
+                        - name
+                        type: object
+                    type: object
+                  bootstrapProperties:
+                    description: BootstrapProperties configuration that will be applied
+                      to the node.
+                    properties:
+                      nifiJvmMemory:
+                        description: JVM memory settings
+                        type: string
+                      overrideConfigMap:
+                        description: Additionnals bootstrap.properties configuration
+                          that will override the one produced based on template and
+                          configuration
+                        properties:
+                          data:
+                            description: The key of the value,in data content, that
+                              we want use.
+                            type: string
+                          name:
+                            description: Name of the configmap that we want to refer.
+                            type: string
+                          namespace:
+                            description: Namespace where is located the secret that
+                              we want to refer.
+                            type: string
+                        required:
+                        - data
+                        - name
+                        type: object
+                      overrideConfigs:
+                        description: Additionnals bootstrap.properties configuration
+                          that will override the one produced based on template and
+                          configurations.
+                        type: string
+                      overrideSecretConfig:
+                        description: Additionnals bootstrap.properties configuration
+                          that will override the one produced based on template, configurations,
+                          overrideConfigMap and overrideConfigs.
+                        properties:
+                          data:
+                            description: The key of the value,in data content, that
+                              we want use.
+                            type: string
+                          name:
+                            description: Name of the configmap that we want to refer.
+                            type: string
+                          namespace:
+                            description: Namespace where is located the secret that
+                              we want to refer.
+                            type: string
+                        required:
+                        - data
+                        - name
+                        type: object
+                    type: object
+                  logbackConfig:
+                    description: Logback configuration that will be applied to the
+                      node.
+                    properties:
+                      replaceConfigMap:
+                        description: logback.xml configuration that will replace the
+                          one produced based on template
+                        properties:
+                          data:
+                            description: The key of the value,in data content, that
+                              we want use.
+                            type: string
+                          name:
+                            description: Name of the configmap that we want to refer.
+                            type: string
+                          namespace:
+                            description: Namespace where is located the secret that
+                              we want to refer.
+                            type: string
+                        required:
+                        - data
+                        - name
+                        type: object
+                      replaceSecretConfig:
+                        description: logback.xml configuration that will replace the
+                          one produced based on template and overrideConfigMap
+                        properties:
+                          data:
+                            description: The key of the value,in data content, that
+                              we want use.
+                            type: string
+                          name:
+                            description: Name of the configmap that we want to refer.
+                            type: string
+                          namespace:
+                            description: Namespace where is located the secret that
+                              we want to refer.
+                            type: string
+                        required:
+                        - data
+                        - name
+                        type: object
+                    type: object
+                  maximumTimerDrivenThreadCount:
+                    description: MaximumTimerDrivenThreadCount define the maximum
+                      number of threads for timer driven processors available to the
+                      system.
+                    format: int32
+                    type: integer
+                  nifiProperties:
+                    description: NifiProperties configuration that will be applied
+                      to the node.
+                    properties:
+                      authorizer:
+                        description: Indicates which of the configured authorizers
+                          in the authorizers.xml file to use https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#authorizer-configuration
+                        type: string
+                      needClientAuth:
+                        description: Nifi security client auth
+                        type: boolean
+                      overrideConfigMap:
+                        description: Additionnals nifi.properties configuration that
+                          will override the one produced based on template and configuration
+                        properties:
+                          data:
+                            description: The key of the value,in data content, that
+                              we want use.
+                            type: string
+                          name:
+                            description: Name of the configmap that we want to refer.
+                            type: string
+                          namespace:
+                            description: Namespace where is located the secret that
+                              we want to refer.
+                            type: string
+                        required:
+                        - data
+                        - name
+                        type: object
+                      overrideConfigs:
+                        description: Additionnals nifi.properties configuration that
+                          will override the one produced based on template, configurations
+                          and overrideConfigMap.
+                        type: string
+                      overrideSecretConfig:
+                        description: Additionnals nifi.properties configuration that
+                          will override the one produced based on template, configurations,
+                          overrideConfigMap and overrideConfigs.
+                        properties:
+                          data:
+                            description: The key of the value,in data content, that
+                              we want use.
+                            type: string
+                          name:
+                            description: Name of the configmap that we want to refer.
+                            type: string
+                          namespace:
+                            description: Namespace where is located the secret that
+                              we want to refer.
+                            type: string
+                        required:
+                        - data
+                        - name
+                        type: object
+                      webProxyHosts:
+                        description: A comma separated list of allowed HTTP Host header
+                          values to consider when NiFi is running securely and will
+                          be receiving requests to a different host[:port] than it
+                          is bound to. https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#web-properties
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  zookeeperProperties:
+                    description: ZookeeperProperties configuration that will be applied
+                      to the node.
+                    properties:
+                      overrideConfigMap:
+                        description: Additionnals zookeeper.properties configuration
+                          that will override the one produced based on template and
+                          configuration
+                        properties:
+                          data:
+                            description: The key of the value,in data content, that
+                              we want use.
+                            type: string
+                          name:
+                            description: Name of the configmap that we want to refer.
+                            type: string
+                          namespace:
+                            description: Namespace where is located the secret that
+                              we want to refer.
+                            type: string
+                        required:
+                        - data
+                        - name
+                        type: object
+                      overrideConfigs:
+                        description: Additionnals zookeeper.properties configuration
+                          that will override the one produced based on template and
+                          configurations.
+                        type: string
+                      overrideSecretConfig:
+                        description: Additionnals zookeeper.properties configuration
+                          that will override the one produced based on template, configurations,
+                          overrideConfigMap and overrideConfigs.
+                        properties:
+                          data:
+                            description: The key of the value,in data content, that
+                              we want use.
+                            type: string
+                          name:
+                            description: Name of the configmap that we want to refer.
+                            type: string
+                          namespace:
+                            description: Namespace where is located the secret that
+                              we want to refer.
+                            type: string
+                        required:
+                        - data
+                        - name
+                        type: object
+                    type: object
+                type: object
+              rootProcessGroupId:
+                description: rootProcessGroupId contains the uuid of the root process
+                  group for this cluster (used if external type)
+                type: string
+              secretRef:
+                description: secretRef reference the secret containing the informations
+                  required to authentiticate to the cluster (used if external type)
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - name
+                type: object
+              service:
+                description: Service defines the policy for services owned by NiFiKop
+                  operator.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations specifies the annotations to attach to
+                      services the operator creates
+                    type: object
+                  headlessEnabled:
+                    description: HeadlessEnabled specifies if the cluster should use
+                      headlessService for Nifi or individual services using service
+                      per nodes may come an handy case of service mesh.
+                    type: boolean
+                required:
+                - headlessEnabled
+                type: object
+              sidecarConfigs:
+                description: SidecarsConfig defines additional sidecar configurations
+                items:
+                  description: A single application container that you want to run
+                    within a pod.
                   properties:
-                    errorCount:
-                      type: integer
-                    lastSuccess:
+                    args:
+                      description: 'Arguments to the entrypoint. The docker image''s
+                        CMD is used if this is not provided. Variable references $(VAR_NAME)
+                        are expanded using the container''s environment. If a variable
+                        cannot be resolved, the reference in the input string will
+                        be unchanged. The $(VAR_NAME) syntax can be escaped with a
+                        double $$, ie: $$(VAR_NAME). Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                      items:
+                        type: string
+                      type: array
+                    command:
+                      description: 'Entrypoint array. Not executed within a shell.
+                        The docker image''s ENTRYPOINT is used if this is not provided.
+                        Variable references $(VAR_NAME) are expanded using the container''s
+                        environment. If a variable cannot be resolved, the reference
+                        in the input string will be unchanged. The $(VAR_NAME) syntax
+                        can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                        references will never be expanded, regardless of whether the
+                        variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                      items:
+                        type: string
+                      type: array
+                    env:
+                      description: List of environment variables to set in the container.
+                        Cannot be updated.
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previous defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. The $(VAR_NAME) syntax
+                              can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                              references will never be expanded, regardless of whether
+                              the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                  spec.serviceAccountName, status.hostIP, status.podIP,
+                                  status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    envFrom:
+                      description: List of sources to populate environment variables
+                        in the container. The keys defined within a source must be
+                        a C_IDENTIFIER. All invalid keys will be reported as an event
+                        when the container is starting. When a key exists in multiple
+                        sources, the value associated with the last source will take
+                        precedence. Values defined by an Env with a duplicate key
+                        will take precedence. Cannot be updated.
+                      items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
+                                type: boolean
+                            type: object
+                          prefix:
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
+                            type: string
+                          secretRef:
+                            description: The Secret to select from
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                            type: object
+                        type: object
+                      type: array
+                    image:
+                      description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                        This field is optional to allow higher level config management
+                        to default or override container images in workload controllers
+                        like Deployments and StatefulSets.'
+                      type: string
+                    imagePullPolicy:
+                      description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                        Defaults to Always if :latest tag is specified, or IfNotPresent
+                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                      type: string
+                    lifecycle:
+                      description: Actions that the management system should take
+                        in response to container lifecycle events. Cannot be updated.
+                      properties:
+                        postStart:
+                          description: 'PostStart is called immediately after a container
+                            is created. If the handler fails, the container is terminated
+                            and restarted according to its restart policy. Other management
+                            of the container blocks until the hook completes. More
+                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                          type: object
+                        preStop:
+                          description: 'PreStop is called immediately before a container
+                            is terminated due to an API request or management event
+                            such as liveness/startup probe failure, preemption, resource
+                            contention, etc. The handler is not called if the container
+                            crashes or exits. The reason for termination is passed
+                            to the handler. The Pod''s termination grace period countdown
+                            begins before the PreStop hooked is executed. Regardless
+                            of the outcome of the handler, the container will eventually
+                            terminate within the Pod''s termination grace period.
+                            Other management of the container blocks until the hook
+                            completes or until the termination grace period is reached.
+                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                          type: object
+                      type: object
+                    livenessProbe:
+                      description: 'Periodic probe of container liveness. Container
+                        will be restarted if the probe fails. Cannot be updated. More
+                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                    name:
+                      description: Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
+                      type: string
+                    ports:
+                      description: List of ports to expose from the container. Exposing
+                        a port here gives the system additional information about
+                        the network connections a container uses, but is primarily
+                        informational. Not specifying a port here DOES NOT prevent
+                        that port from being exposed. Any port which is listening
+                        on the default "0.0.0.0" address inside a container will be
+                        accessible from the network. Cannot be updated.
+                      items:
+                        description: ContainerPort represents a network port in a
+                          single container.
+                        properties:
+                          containerPort:
+                            description: Number of port to expose on the pod's IP
+                              address. This must be a valid port number, 0 < x < 65536.
+                            format: int32
+                            type: integer
+                          hostIP:
+                            description: What host IP to bind the external port to.
+                            type: string
+                          hostPort:
+                            description: Number of port to expose on the host. If
+                              specified, this must be a valid port number, 0 < x <
+                              65536. If HostNetwork is specified, this must match
+                              ContainerPort. Most containers do not need this.
+                            format: int32
+                            type: integer
+                          name:
+                            description: If specified, this must be an IANA_SVC_NAME
+                              and unique within the pod. Each named port in a pod
+                              must have a unique name. Name for the port that can
+                              be referred to by services.
+                            type: string
+                          protocol:
+                            default: TCP
+                            description: Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
+                            type: string
+                        required:
+                        - containerPort
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - containerPort
+                      - protocol
+                      x-kubernetes-list-type: map
+                    readinessProbe:
+                      description: 'Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe
+                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                    resources:
+                      description: 'Compute Resources required by this container.
+                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    securityContext:
+                      description: 'Security options the pod should run with. More
+                        info: https://kubernetes.io/docs/concepts/policy/security-context/
+                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                      properties:
+                        allowPrivilegeEscalation:
+                          description: 'AllowPrivilegeEscalation controls whether
+                            a process can gain more privileges than its parent process.
+                            This bool directly controls if the no_new_privs flag will
+                            be set on the container process. AllowPrivilegeEscalation
+                            is true always when the container is: 1) run as Privileged
+                            2) has CAP_SYS_ADMIN'
+                          type: boolean
+                        capabilities:
+                          description: The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by
+                            the container runtime.
+                          properties:
+                            add:
+                              description: Added capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                            drop:
+                              description: Removed capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                          type: object
+                        privileged:
+                          description: Run container in privileged mode. Processes
+                            in privileged containers are essentially equivalent to
+                            root on the host. Defaults to false.
+                          type: boolean
+                        procMount:
+                          description: procMount denotes the type of proc mount to
+                            use for the containers. The default is DefaultProcMount
+                            which uses the container runtime defaults for readonly
+                            paths and masked paths. This requires the ProcMountType
+                            feature flag to be enabled.
+                          type: string
+                        readOnlyRootFilesystem:
+                          description: Whether this container has a read-only root
+                            filesystem. Default is false.
+                          type: boolean
+                        runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both
+                            SecurityContext and PodSecurityContext, the value specified
+                            in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in PodSecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: The seccomp options to use by this container.
+                            If seccomp options are provided at both the pod & container
+                            level, the container options override the pod options.
+                          properties:
+                            localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile
+                                must be preconfigured on the node to work. Must be
+                                a descending path, relative to the kubelet's configured
+                                seccomp profile location. Must only be set if type
+                                is "Localhost".
+                              type: string
+                            type:
+                              description: "type indicates which kind of seccomp profile
+                                will be applied. Valid options are: \n Localhost -
+                                a profile defined in a file on the node should be
+                                used. RuntimeDefault - the container runtime default
+                                profile should be used. Unconfined - no profile should
+                                be applied."
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options from the PodSecurityContext
+                            will be used. If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    startupProbe:
+                      description: 'StartupProbe indicates that the Pod has successfully
+                        initialized. If specified, no other probes are executed until
+                        this completes successfully. If this probe fails, the Pod
+                        will be restarted, just as if the livenessProbe failed. This
+                        can be used to provide different probe parameters at the beginning
+                        of a Pod''s lifecycle, when it might take a long time to load
+                        data or warm a cache, than during steady-state operation.
+                        This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                    stdin:
+                      description: Whether this container should allocate a buffer
+                        for stdin in the container runtime. If this is not set, reads
+                        from stdin in the container will always result in EOF. Default
+                        is false.
+                      type: boolean
+                    stdinOnce:
+                      description: Whether the container runtime should close the
+                        stdin channel after it has been opened by a single attach.
+                        When stdin is true the stdin stream will remain open across
+                        multiple attach sessions. If stdinOnce is set to true, stdin
+                        is opened on container start, is empty until the first client
+                        attaches to stdin, and then remains open and accepts data
+                        until the client disconnects, at which time stdin is closed
+                        and remains closed until the container is restarted. If this
+                        flag is false, a container processes that reads from stdin
+                        will never receive an EOF. Default is false
+                      type: boolean
+                    terminationMessagePath:
+                      description: 'Optional: Path at which the file to which the
+                        container''s termination message will be written is mounted
+                        into the container''s filesystem. Message written is intended
+                        to be brief final status, such as an assertion failure message.
+                        Will be truncated by the node if greater than 4096 bytes.
+                        The total message length across all containers will be limited
+                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                      type: string
+                    terminationMessagePolicy:
+                      description: Indicate how the termination message should be
+                        populated. File will use the contents of terminationMessagePath
+                        to populate the container status message on both success and
+                        failure. FallbackToLogsOnError will use the last chunk of
+                        container log output if the termination message file is empty
+                        and the container exited with an error. The log output is
+                        limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
+                        to File. Cannot be updated.
+                      type: string
+                    tty:
+                      description: Whether this container should allocate a TTY for
+                        itself, also requires 'stdin' to be true. Default is false.
+                      type: boolean
+                    volumeDevices:
+                      description: volumeDevices is the list of block devices to be
+                        used by the container.
+                      items:
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
+                        properties:
+                          devicePath:
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
+                            type: string
+                          name:
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
+                            type: string
+                        required:
+                        - devicePath
+                        - name
+                        type: object
+                      type: array
+                    volumeMounts:
+                      description: Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
+                      items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume
+                              should be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are
+                              propagated from the host to container and the other
+                              way around. When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted. Behaves similarly
+                              to SubPath but environment variable references $(VAR_NAME)
+                              are expanded using the container's environment. Defaults
+                              to "" (volume's root). SubPathExpr and SubPath are mutually
+                              exclusive.
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
+                    workingDir:
+                      description: Container's working directory. If not specified,
+                        the container runtime's default will be used, which might
+                        be configured in the container image. Cannot be updated.
                       type: string
                   required:
-                    - errorCount
-                    - lastSuccess
+                  - name
                   type: object
-                rootProcessGroupId:
-                  description:
-                    RootProcessGroupId contains the uuid of the root process
-                    group for this cluster
-                  type: string
-                state:
-                  description: ClusterState holds info about the cluster state
-                  type: string
-              required:
-                - state
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              type:
+                description: type defines if the cluster is internal (i.e manager
+                  by the operator) or external.
+                enum:
+                - external
+                - internal
+                type: string
+              zkAddress:
+                description: 'zKAddress specifies the ZooKeeper connection string
+                  in the form hostname:port where host and port are those of a Zookeeper
+                  server. TODO: rework for nice zookeeper connect string ='
+                type: string
+              zkPath:
+                description: zKPath specifies the Zookeeper chroot path as part of
+                  its Zookeeper connection string which puts its data under same path
+                  in the global ZooKeeper namespace.
+                type: string
+            required:
+            - nodes
+            type: object
+          status:
+            description: NifiClusterStatus defines the observed state of NifiCluster
+            properties:
+              nodesState:
+                additionalProperties:
+                  description: NifiState holds information about nifi state
+                  properties:
+                    configurationState:
+                      description: ConfigurationState holds info about the config
+                      type: string
+                    gracefulActionState:
+                      description: GracefulActionState holds info about nifi cluster
+                        action status
+                      properties:
+                        TaskStarted:
+                          description: TaskStarted hold the time when the execution
+                            started
+                          type: string
+                        actionState:
+                          description: ActionState holds the information about Action
+                            state
+                          type: string
+                        actionStep:
+                          description: ActionStep holds info about the action step
+                            ran
+                          type: string
+                        errorMessage:
+                          description: ErrorMessage holds the information what happened
+                            with Nifi Cluster
+                          type: string
+                      required:
+                      - actionState
+                      - errorMessage
+                      type: object
+                    initClusterNode:
+                      description: InitClusterNode contains if this nodes was part
+                        of the initial cluster
+                      type: boolean
+                    podIsReady:
+                      description: PodIsReady whether or not the associated pod is
+                        ready
+                      type: boolean
+                  required:
+                  - configurationState
+                  - gracefulActionState
+                  - initClusterNode
+                  - podIsReady
+                  type: object
+                description: Store the state of each nifi node
+                type: object
+              prometheusReportingTask:
+                description: PrometheusReportingTask contains the status of the prometheus
+                  reporting task managed by the operator
+                properties:
+                  id:
+                    description: The nifi reporting task's id
+                    type: string
+                  version:
+                    description: The last nifi reporting task revision version catched
+                    format: int64
+                    type: integer
+                required:
+                - id
+                - version
+                type: object
+              rollingUpgradeStatus:
+                description: RollingUpgradeStatus defines status of rolling upgrade
+                properties:
+                  errorCount:
+                    type: integer
+                  lastSuccess:
+                    type: string
+                required:
+                - errorCount
+                - lastSuccess
+                type: object
+              rootProcessGroupId:
+                description: RootProcessGroupId contains the uuid of the root process
+                  group for this cluster
+                type: string
+              state:
+                description: ClusterState holds info about the cluster state
+                type: string
+            required:
+            - state
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/helm/nifikop/crds/nifi.orange.com_nifidataflows.yaml
+++ b/helm/nifikop/crds/nifi.orange.com_nifidataflows.yaml
@@ -53,9 +53,21 @@ spec:
               flowId:
                 description: the UUID of the flow to run.
                 type: string
+              flowPosition:
+                description: the position of your dataflow in the canvas.
+                properties:
+                  posX:
+                    description: The x coordinate.
+                    format: int64
+                    type: integer
+                  posY:
+                    description: The y coordinate.
+                    format: int64
+                    type: integer
+                type: object
               flowVersion:
-                description: the version of the flow to run, if not present or equals
-                  to -1, then the latest version of flow will be used.
+                description: the version of the flow to run, then the latest version
+                  of flow will be used.
                 format: int32
                 type: integer
               parameterContextRef:

--- a/helm/nifikop/crds/nifi.orange.com_nifiregistryclients.yaml
+++ b/helm/nifikop/crds/nifi.orange.com_nifiregistryclients.yaml
@@ -39,7 +39,7 @@ spec:
             properties:
               clusterRef:
                 description: contains the reference to the NifiCluster with the one
-                  the dataflow is linked.
+                  the registry client is linked.
                 properties:
                   name:
                     type: string


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR adjusts the makefile to output the generated CRDs into the helm chart directory as well. This is to make sure that the helm chart CRDs don't fall out of line with the baseline, as has happened several times in the past. See #119.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
 See above.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
- [x] Append changelog with changes
